### PR TITLE
feat: event delegation to fix edit-mode DOM node retention leak

### DIFF
--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -92,8 +92,10 @@
             <div id="test-panel-body"></div>
           </details>
 
-          <!-- Rules container -->
+          <!-- Pagination controls + Rules container -->
+          <div id="rules-pagination" hidden></div>
           <div id="rules-container"></div>
+          <div id="rules-pagination-bottom" hidden></div>
 
           <!-- Raw JSON collapsible -->
           <details id="raw-json" hidden>

--- a/packages/web/src/__tests__/editor.test.ts
+++ b/packages/web/src/__tests__/editor.test.ts
@@ -208,7 +208,7 @@ describe("editor", () => {
 
       // Change first substat to ATK% (ID:2, IsFlat:false = "2:0")
       statSelects[0].value = "2:0";
-      statSelects[0].dispatchEvent(new Event("change"));
+      statSelects[0].dispatchEvent(new Event("change", { bubbles: true }));
 
       expect(rule.Substats[0].ID).toBe(2);
       expect(rule.Substats[0].IsFlat).toBe(false);
@@ -225,7 +225,7 @@ describe("editor", () => {
 
       const statSelects = document.querySelectorAll(".edit-sub-stat") as NodeListOf<HTMLSelectElement>;
       statSelects[0].value = "-1";
-      statSelects[0].dispatchEvent(new Event("change"));
+      statSelects[0].dispatchEvent(new Event("change", { bubbles: true }));
 
       expect(rule.Substats[0].ID).toBe(-1);
       expect(rule.Substats[0].Value).toBe(0);
@@ -258,7 +258,7 @@ describe("editor", () => {
       // Change condition
       const condSelects = document.querySelectorAll(".edit-sub-cond") as NodeListOf<HTMLSelectElement>;
       condSelects[0].value = ">";
-      condSelects[0].dispatchEvent(new Event("change"));
+      condSelects[0].dispatchEvent(new Event("change", { bubbles: true }));
 
       // The spread in the handler preserves extra fields
       expect((rule.Substats[0] as Record<string, unknown>)["ExtraField"]).toBe(42);
@@ -308,6 +308,40 @@ describe("editor", () => {
       expect(cards[0].dataset.ruleIndex).toBe("0");
       expect(cards[1].dataset.ruleIndex).toBe("1");
       expect(cards[2].dataset.ruleIndex).toBe("2");
+    });
+  });
+
+  describe("data attributes for delegation", () => {
+    it("Keep button has data-action='keep-toggle'", () => {
+      const filter = makeFilter([defaultRule()]);
+      renderEditableRules(filter, noopCallbacks());
+      const btn = document.querySelector("[data-action='keep-toggle']");
+      expect(btn).not.toBeNull();
+      expect(btn!.textContent).toBe("Keep");
+    });
+
+    it("delete button has data-action='delete'", () => {
+      const filter = makeFilter([defaultRule()]);
+      renderEditableRules(filter, noopCallbacks());
+      const btn = document.querySelector("[data-action='delete']");
+      expect(btn).not.toBeNull();
+    });
+
+    it("substat rows have data-sub-index", () => {
+      const filter = makeFilter([defaultRule()]);
+      renderEditableRules(filter, noopCallbacks());
+      const rows = document.querySelectorAll(".edit-substat-row");
+      expect(rows.length).toBe(4);
+      expect((rows[0] as HTMLElement).dataset.subIndex).toBe("0");
+      expect((rows[3] as HTMLElement).dataset.subIndex).toBe("3");
+    });
+
+    it("field selects have data-field", () => {
+      const filter = makeFilter([defaultRule()]);
+      renderEditableRules(filter, noopCallbacks());
+      const rankField = document.querySelector("[data-field='rank']");
+      expect(rankField).not.toBeNull();
+      expect(rankField!.tagName).toBe("SELECT");
     });
   });
 });

--- a/packages/web/src/__tests__/editor.test.ts
+++ b/packages/web/src/__tests__/editor.test.ts
@@ -7,7 +7,10 @@ import type { RuleEditorCallbacks } from "../editor.js";
 
 // Minimal DOM setup — vitest uses JSDOM by default
 function setupDOM(): void {
-  document.body.innerHTML = '<div id="rules-container"></div>';
+  document.body.innerHTML =
+    '<div id="rules-pagination" hidden></div>' +
+    '<div id="rules-container"></div>' +
+    '<div id="rules-pagination-bottom" hidden></div>';
 }
 
 function makeFilter(rules: HsfRule[]): HsfFilter {

--- a/packages/web/src/editor.ts
+++ b/packages/web/src/editor.ts
@@ -1,5 +1,9 @@
 /**
  * Editable rule cards for the Viewer's edit mode.
+ *
+ * Uses event delegation: a single set of listeners on #rules-container
+ * handles all card interactions. This eliminates per-card closures that
+ * previously retained detached DOM nodes across page switches.
  */
 import type { HsfFilter, HsfRule, HsfSubstat } from "@rslh/core";
 import {
@@ -9,7 +13,7 @@ import {
   FACTION_NAMES,
   emptySubstat,
 } from "@rslh/core";
-import { abortPageListeners, esc, renderPaginatedCards } from "./render.js";
+import { esc, getCurrentFilter, renderPaginatedCards } from "./render.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -45,6 +49,9 @@ const CONDITION_OPTIONS = [">=", ">", "=", "<=", "<"];
 /** Index of the rule currently being dragged, or -1 if none. */
 let dragSourceIndex = -1;
 
+/** Current callbacks — set once when edit mode starts, read by delegation handlers. */
+let currentCallbacks: RuleEditorCallbacks | null = null;
+
 function clearDropIndicators(container: Element): void {
   for (const el of container.querySelectorAll(".edit-drop-above, .edit-drop-below")) {
     el.classList.remove("edit-drop-above", "edit-drop-below");
@@ -52,11 +59,252 @@ function clearDropIndicators(container: Element): void {
 }
 
 // ---------------------------------------------------------------------------
-// Public API
+// Delegation handlers
 // ---------------------------------------------------------------------------
 
-// Single dragleave handler for the rules container — registered once to
-// avoid accumulating listeners on every renderEditableRules call.
+function handleContainerClick(e: MouseEvent): void {
+  const target = e.target as HTMLElement;
+  const action = target.closest("[data-action]") as HTMLElement | null;
+  if (!action) return;
+  const card = action.closest(".edit-card") as HTMLElement | null;
+  if (!card) return;
+  const index = Number(card.dataset.ruleIndex);
+  const filter = getCurrentFilter();
+  if (!filter || !currentCallbacks) return;
+  const rule = filter.Rules[index];
+
+  switch (action.dataset.action) {
+    case "keep-toggle": {
+      rule.Keep = !rule.Keep;
+      action.textContent = rule.Keep ? "Keep" : "Sell";
+      action.className = `edit-badge-toggle ${rule.Keep ? "badge-keep" : "badge-sell"}`;
+      card.classList.toggle("keep", rule.Keep);
+      card.classList.toggle("sell", !rule.Keep);
+      currentCallbacks.onRuleChange(index, rule);
+      break;
+    }
+    case "use-toggle": {
+      rule.Use = !rule.Use;
+      action.textContent = rule.Use ? "Active" : "Inactive";
+      action.className = `edit-badge-toggle ${rule.Use ? "badge-active" : "badge-inactive"}`;
+      card.classList.toggle("inactive", !rule.Use);
+      currentCallbacks.onRuleChange(index, rule);
+      break;
+    }
+    case "move-up":
+      currentCallbacks.onRuleMove(index, index - 1);
+      break;
+    case "move-down":
+      currentCallbacks.onRuleMove(index, index + 1);
+      break;
+    case "delete":
+      currentCallbacks.onRuleDelete(index);
+      break;
+    case "set-toggle": {
+      const panel = card.querySelector(".set-selector-panel") as HTMLElement;
+      if (!panel.children.length) {
+        populateSetPanel(panel, rule.ArtifactSet ?? []);
+      }
+      panel.classList.toggle("open");
+      if (panel.classList.contains("open")) {
+        const search = panel.querySelector<HTMLInputElement>(".set-selector-search");
+        if (search) search.focus();
+      }
+      break;
+    }
+  }
+}
+
+function handleContainerChange(e: Event): void {
+  const target = e.target as HTMLElement;
+  const card = target.closest(".edit-card") as HTMLElement | null;
+  if (!card) return;
+  const index = Number(card.dataset.ruleIndex);
+  const filter = getCurrentFilter();
+  if (!filter || !currentCallbacks) return;
+  const rule = filter.Rules[index];
+
+  // Field selects (Rank, Rarity, Level, Faction, Main Stat)
+  const field = (target as HTMLElement).dataset.field;
+  if (field) {
+    const val = (target as HTMLSelectElement).value;
+    switch (field) {
+      case "rank": rule.Rank = Number(val); break;
+      case "rarity": rule.Rarity = Number(val); break;
+      case "level": rule.LVLForCheck = Number(val); break;
+      case "faction": rule.Faction = Number(val); break;
+      case "main-stat": {
+        if (val === "-1") {
+          rule.MainStatID = -1;
+          rule.MainStatF = 1;
+        } else {
+          const [statId, flatFlag] = val.split(":").map(Number);
+          rule.MainStatID = statId;
+          rule.MainStatF = flatFlag === 1 ? 0 : 1;
+        }
+        break;
+      }
+    }
+    currentCallbacks.onRuleChange(index, rule);
+    return;
+  }
+
+  // Substat changes
+  const row = target.closest(".edit-substat-row") as HTMLElement | null;
+  if (row) {
+    const subIndex = Number(row.dataset.subIndex);
+    if (target.classList.contains("edit-sub-stat")) {
+      const sv = (target as HTMLSelectElement).value;
+      const condSelect = row.querySelector(".edit-sub-cond") as HTMLSelectElement;
+      const valueInput = row.querySelector('input[type="number"]') as HTMLInputElement;
+      if (sv === "-1") {
+        rule.Substats[subIndex] = emptySubstat();
+        condSelect.disabled = true;
+        valueInput.disabled = true;
+        condSelect.value = ">=";
+        valueInput.value = "0";
+      } else {
+        const [statId, flatFlag] = sv.split(":").map(Number);
+        rule.Substats[subIndex] = {
+          ...rule.Substats[subIndex],
+          ID: statId,
+          IsFlat: flatFlag === 1,
+          NotAvailable: false,
+          Condition: condSelect.value || ">=",
+          Value: Number(valueInput.value) || 0,
+        };
+        condSelect.disabled = false;
+        valueInput.disabled = false;
+      }
+    } else if (target.classList.contains("edit-sub-cond")) {
+      rule.Substats[subIndex] = {
+        ...rule.Substats[subIndex],
+        Condition: (target as HTMLSelectElement).value,
+      };
+    }
+    currentCallbacks.onRuleChange(index, rule);
+    return;
+  }
+
+  // Set checkboxes
+  const actionAttr = (target as HTMLElement).dataset.action;
+  if (actionAttr === "set-check") {
+    const checkbox = target as HTMLInputElement;
+    const setId = Number(checkbox.dataset.setId);
+    let sets = rule.ArtifactSet ?? [];
+    if (checkbox.checked) {
+      sets.push(setId);
+    } else {
+      sets = sets.filter((s) => s !== setId);
+    }
+    rule.ArtifactSet = sets.length > 0 ? sets : undefined;
+    const toggle = card.querySelector("[data-action='set-toggle']") as HTMLElement;
+    toggle.textContent = summariseSets(sets);
+    currentCallbacks.onRuleChange(index, rule);
+    return;
+  }
+
+  // Slot checkboxes
+  if (actionAttr === "slot-check") {
+    const checkbox = target as HTMLInputElement;
+    const slotId = Number(checkbox.dataset.slotId);
+    let slots = rule.ArtifactType ?? [];
+    if (checkbox.checked) {
+      slots.push(slotId);
+    } else {
+      slots = slots.filter((s) => s !== slotId);
+    }
+    rule.ArtifactType = slots.length > 0 ? slots : undefined;
+    currentCallbacks.onRuleChange(index, rule);
+    return;
+  }
+}
+
+function handleContainerInput(e: Event): void {
+  const target = e.target as HTMLElement;
+  const card = target.closest(".edit-card") as HTMLElement | null;
+  if (!card) return;
+
+  // Set search filter
+  if ((target as HTMLElement).dataset.action === "set-search") {
+    const q = (target as HTMLInputElement).value.toLowerCase();
+    const list = target.closest(".set-selector-panel")?.querySelector(".set-selector-list");
+    if (list) {
+      for (const item of list.children) {
+        const text = (item as HTMLElement).textContent!.toLowerCase();
+        (item as HTMLElement).hidden = !text.includes(q);
+      }
+    }
+    return;
+  }
+
+  // Substat value input
+  const row = target.closest(".edit-substat-row") as HTMLElement | null;
+  if (row && target instanceof HTMLInputElement && target.type === "number") {
+    const index = Number(card.dataset.ruleIndex);
+    const filter = getCurrentFilter();
+    if (!filter || !currentCallbacks) return;
+    const rule = filter.Rules[index];
+    const subIndex = Number(row.dataset.subIndex);
+    rule.Substats[subIndex] = {
+      ...rule.Substats[subIndex],
+      Value: Number(target.value) || 0,
+    };
+    currentCallbacks.onRuleChange(index, rule);
+    return;
+  }
+}
+
+// --- Drag delegation ---
+
+function handleContainerDragStart(e: DragEvent): void {
+  const card = (e.target as Element).closest(".edit-card") as HTMLElement | null;
+  if (!card) return;
+  dragSourceIndex = Number(card.dataset.ruleIndex);
+  e.dataTransfer!.effectAllowed = "move";
+  e.dataTransfer!.setData("text/plain", String(dragSourceIndex));
+  card.classList.add("edit-card-dragging");
+}
+
+function handleContainerDragEnd(e: DragEvent): void {
+  const card = (e.target as Element).closest(".edit-card") as HTMLElement | null;
+  if (card) card.classList.remove("edit-card-dragging");
+  dragSourceIndex = -1;
+  const container = document.getElementById("rules-container")!;
+  clearDropIndicators(container);
+}
+
+function handleContainerDragOver(e: DragEvent): void {
+  if (dragSourceIndex === -1) return;
+  const card = (e.target as Element).closest(".edit-card") as HTMLElement | null;
+  if (!card) return;
+  e.preventDefault();
+  e.dataTransfer!.dropEffect = "move";
+  const container = card.parentElement!;
+  clearDropIndicators(container);
+  const targetIndex = Number(card.dataset.ruleIndex);
+  if (targetIndex === dragSourceIndex) return;
+  const rect = card.getBoundingClientRect();
+  const midY = rect.top + rect.height / 2;
+  if (e.clientY < midY) card.classList.add("edit-drop-above");
+  else card.classList.add("edit-drop-below");
+}
+
+function handleContainerDrop(e: DragEvent): void {
+  e.preventDefault();
+  const from = dragSourceIndex;
+  if (from === -1) return;
+  const card = (e.target as Element).closest(".edit-card") as HTMLElement | null;
+  if (!card || !currentCallbacks) return;
+  const targetIndex = Number(card.dataset.ruleIndex);
+  if (from === targetIndex) return;
+  const rect = card.getBoundingClientRect();
+  const midY = rect.top + rect.height / 2;
+  let to = e.clientY < midY ? targetIndex : targetIndex + 1;
+  if (from < to) to--;
+  if (from !== to) currentCallbacks.onRuleMove(from, to);
+}
+
 function handleContainerDragLeave(e: DragEvent): void {
   const container = document.getElementById("rules-container")!;
   if (!container.contains(e.relatedTarget as Node)) {
@@ -64,37 +312,54 @@ function handleContainerDragLeave(e: DragEvent): void {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
 export function renderEditableRules(
   filter: HsfFilter,
   callbacks: RuleEditorCallbacks,
 ): void {
+  currentCallbacks = callbacks;
   const total = filter.Rules.length;
   renderPaginatedCards(
     filter,
-    (rule, i, signal) => buildEditableRuleCard(rule, i, total, callbacks, signal),
+    (rule, i) => buildEditableRuleCard(rule, i, total),
   );
 
-  // Container-level drop indicator cleanup — same function reference so
-  // addEventListener is a no-op if already registered.
   const container = document.getElementById("rules-container")!;
+  container.addEventListener("click", handleContainerClick);
+  container.addEventListener("change", handleContainerChange);
+  container.addEventListener("input", handleContainerInput);
+  container.addEventListener("dragstart", handleContainerDragStart);
+  container.addEventListener("dragend", handleContainerDragEnd);
+  container.addEventListener("dragover", handleContainerDragOver);
+  container.addEventListener("drop", handleContainerDrop);
   container.addEventListener("dragleave", handleContainerDragLeave);
 }
 
 export function clearEditor(): void {
-  abortPageListeners();
-  document.getElementById("rules-container")!.innerHTML = "";
+  currentCallbacks = null;
+  const container = document.getElementById("rules-container")!;
+  container.removeEventListener("click", handleContainerClick);
+  container.removeEventListener("change", handleContainerChange);
+  container.removeEventListener("input", handleContainerInput);
+  container.removeEventListener("dragstart", handleContainerDragStart);
+  container.removeEventListener("dragend", handleContainerDragEnd);
+  container.removeEventListener("dragover", handleContainerDragOver);
+  container.removeEventListener("drop", handleContainerDrop);
+  container.removeEventListener("dragleave", handleContainerDragLeave);
+  container.innerHTML = "";
 }
 
 // ---------------------------------------------------------------------------
-// Card builder
+// Card builder — pure DOM construction, no event listeners
 // ---------------------------------------------------------------------------
 
 function buildEditableRuleCard(
   rule: HsfRule,
   index: number,
   total: number,
-  cb: RuleEditorCallbacks,
-  signal: AbortSignal,
 ): HTMLElement {
   const card = document.createElement("div");
   card.className = "edit-card";
@@ -103,58 +368,6 @@ function buildEditableRuleCard(
   card.draggable = true;
   if (!rule.Use) card.classList.add("inactive");
   card.classList.add(rule.Keep ? "keep" : "sell");
-
-  // --- Drag-and-drop ---
-  card.addEventListener("dragstart", (e) => {
-    dragSourceIndex = index;
-    e.dataTransfer!.effectAllowed = "move";
-    e.dataTransfer!.setData("text/plain", String(index));
-    card.classList.add("edit-card-dragging");
-  }, { signal });
-
-  card.addEventListener("dragend", () => {
-    card.classList.remove("edit-card-dragging");
-    dragSourceIndex = -1;
-    const container = card.parentElement;
-    if (container) clearDropIndicators(container);
-  }, { signal });
-
-  card.addEventListener("dragover", (e) => {
-    if (dragSourceIndex === -1) return;
-    e.preventDefault();
-    e.dataTransfer!.dropEffect = "move";
-
-    const container = card.parentElement!;
-    clearDropIndicators(container);
-
-    const targetIndex = Number(card.dataset.ruleIndex);
-    if (targetIndex === dragSourceIndex) return;
-
-    const rect = card.getBoundingClientRect();
-    const midY = rect.top + rect.height / 2;
-    if (e.clientY < midY) {
-      card.classList.add("edit-drop-above");
-    } else {
-      card.classList.add("edit-drop-below");
-    }
-  }, { signal });
-
-  card.addEventListener("drop", (e) => {
-    e.preventDefault();
-    const from = dragSourceIndex;
-    if (from === -1) return;
-
-    const targetIndex = Number(card.dataset.ruleIndex);
-    if (from === targetIndex) return;
-
-    const rect = card.getBoundingClientRect();
-    const midY = rect.top + rect.height / 2;
-    let to = e.clientY < midY ? targetIndex : targetIndex + 1;
-    // Adjust: if dragging downward past the original position, the splice
-    // removes the source first, shifting indices down by 1
-    if (from < to) to--;
-    if (from !== to) cb.onRuleMove(from, to);
-  }, { signal });
 
   // --- Header ---
   const header = document.createElement("div");
@@ -177,14 +390,7 @@ function buildEditableRuleCard(
   keepBtn.type = "button";
   keepBtn.className = `edit-badge-toggle ${rule.Keep ? "badge-keep" : "badge-sell"}`;
   keepBtn.textContent = rule.Keep ? "Keep" : "Sell";
-  keepBtn.addEventListener("click", () => {
-    rule.Keep = !rule.Keep;
-    keepBtn.textContent = rule.Keep ? "Keep" : "Sell";
-    keepBtn.className = `edit-badge-toggle ${rule.Keep ? "badge-keep" : "badge-sell"}`;
-    card.classList.toggle("keep", rule.Keep);
-    card.classList.toggle("sell", !rule.Keep);
-    cb.onRuleChange(index, rule);
-  }, { signal });
+  keepBtn.dataset.action = "keep-toggle";
   header.appendChild(keepBtn);
 
   // Active/Inactive toggle
@@ -192,13 +398,7 @@ function buildEditableRuleCard(
   useBtn.type = "button";
   useBtn.className = `edit-badge-toggle ${rule.Use ? "badge-active" : "badge-inactive"}`;
   useBtn.textContent = rule.Use ? "Active" : "Inactive";
-  useBtn.addEventListener("click", () => {
-    rule.Use = !rule.Use;
-    useBtn.textContent = rule.Use ? "Active" : "Inactive";
-    useBtn.className = `edit-badge-toggle ${rule.Use ? "badge-active" : "badge-inactive"}`;
-    card.classList.toggle("inactive", !rule.Use);
-    cb.onRuleChange(index, rule);
-  }, { signal });
+  useBtn.dataset.action = "use-toggle";
   header.appendChild(useBtn);
 
   // Move up
@@ -208,7 +408,7 @@ function buildEditableRuleCard(
   upBtn.textContent = "\u25b2";
   upBtn.title = "Move up";
   upBtn.disabled = index === 0;
-  upBtn.addEventListener("click", () => cb.onRuleMove(index, index - 1), { signal });
+  upBtn.dataset.action = "move-up";
   header.appendChild(upBtn);
 
   // Move down
@@ -218,7 +418,7 @@ function buildEditableRuleCard(
   downBtn.textContent = "\u25bc";
   downBtn.title = "Move down";
   downBtn.disabled = index === total - 1;
-  downBtn.addEventListener("click", () => cb.onRuleMove(index, index + 1), { signal });
+  downBtn.dataset.action = "move-down";
   header.appendChild(downBtn);
 
   // Delete
@@ -227,7 +427,7 @@ function buildEditableRuleCard(
   delBtn.className = "edit-delete-btn";
   delBtn.textContent = "\u00d7";
   delBtn.title = "Delete rule";
-  delBtn.addEventListener("click", () => cb.onRuleDelete(index), { signal });
+  delBtn.dataset.action = "delete";
   header.appendChild(delBtn);
 
   card.appendChild(header);
@@ -236,78 +436,47 @@ function buildEditableRuleCard(
   const body = document.createElement("div");
   body.className = "edit-body";
 
-  // Sets — searchable multi-select dropdown (reuse pattern from generator)
-  body.appendChild(buildSetField(rule, index, cb, signal));
+  body.appendChild(buildSetField(rule));
+  body.appendChild(buildSlotField(rule));
+  body.appendChild(buildSelectField("Rank", "rank", rule.Rank, [
+    { value: 0, label: "Any" },
+    { value: 5, label: "5-star" },
+    { value: 6, label: "6-star" },
+  ]));
 
-  // Slots — checkbox grid
-  body.appendChild(buildSlotField(rule, index, cb, signal));
-
-  // Rank dropdown
-  body.appendChild(
-    buildSelectField("Rank", rule.Rank, [
-      { value: 0, label: "Any" },
-      { value: 5, label: "5-star" },
-      { value: 6, label: "6-star" },
-    ], (val) => {
-      rule.Rank = val;
-      cb.onRuleChange(index, rule);
-    }, signal),
-  );
-
-  // Rarity dropdown
   const rarityOpts: { value: number; label: string }[] = [{ value: 0, label: "Any" }];
   for (const [id, name] of Object.entries(HSF_RARITY_IDS)) {
     rarityOpts.push({ value: Number(id), label: name });
   }
-  body.appendChild(
-    buildSelectField("Rarity", rule.Rarity, rarityOpts, (val) => {
-      rule.Rarity = val;
-      cb.onRuleChange(index, rule);
-    }, signal),
-  );
+  body.appendChild(buildSelectField("Rarity", "rarity", rule.Rarity, rarityOpts));
+  body.appendChild(buildMainStatField(rule));
 
-  // Main Stat dropdown — encodes both MainStatID and MainStatF
-  body.appendChild(buildMainStatField(rule, index, cb, signal));
-
-  // Level dropdown
   const levelOpts = Array.from({ length: 17 }, (_, i) => ({ value: i, label: String(i) }));
-  body.appendChild(
-    buildSelectField("Level", rule.LVLForCheck, levelOpts, (val) => {
-      rule.LVLForCheck = val;
-      cb.onRuleChange(index, rule);
-    }, signal),
-  );
+  body.appendChild(buildSelectField("Level", "level", rule.LVLForCheck, levelOpts));
 
-  // Faction dropdown
   const factionOpts: { value: number; label: string }[] = [{ value: 0, label: "Any" }];
   for (const [id, name] of Object.entries(FACTION_NAMES)) {
     factionOpts.push({ value: Number(id), label: name });
   }
-  body.appendChild(
-    buildSelectField("Faction", rule.Faction, factionOpts, (val) => {
-      rule.Faction = val;
-      cb.onRuleChange(index, rule);
-    }, signal),
-  );
+  body.appendChild(buildSelectField("Faction", "faction", rule.Faction, factionOpts));
 
   card.appendChild(body);
 
   // --- Substats ---
-  card.appendChild(buildSubstatsSection(rule, index, cb, signal));
+  card.appendChild(buildSubstatsSection(rule));
 
   return card;
 }
 
 // ---------------------------------------------------------------------------
-// Field builders
+// Field builders — pure DOM, no listeners
 // ---------------------------------------------------------------------------
 
 function buildSelectField(
   labelText: string,
+  fieldName: string,
   current: number,
   options: { value: number; label: string }[],
-  onChange: (value: number) => void,
-  signal: AbortSignal,
 ): HTMLElement {
   const field = document.createElement("div");
   field.className = "edit-field";
@@ -317,6 +486,7 @@ function buildSelectField(
   field.appendChild(label);
 
   const select = document.createElement("select");
+  select.dataset.field = fieldName;
   for (const opt of options) {
     const option = document.createElement("option");
     option.value = String(opt.value);
@@ -324,32 +494,24 @@ function buildSelectField(
     if (opt.value === current) option.selected = true;
     select.appendChild(option);
   }
-  select.addEventListener("change", () => onChange(Number(select.value)), { signal });
   field.appendChild(select);
 
   return field;
 }
 
 // ---------------------------------------------------------------------------
-// Main Stat selector — encodes MainStatID + MainStatF together
+// Main Stat selector
 // ---------------------------------------------------------------------------
 
-/** All main stat options: same variants as SUBSTAT_OPTIONS. */
 const MAIN_STAT_OPTIONS = SUBSTAT_OPTIONS;
 
 function encodeMainStat(rule: HsfRule): string {
   if (rule.MainStatID === -1) return "-1";
-  // MainStatF: 0 = flat, 1 = percentage
   const isFlat = rule.MainStatF === 0;
   return `${rule.MainStatID}:${isFlat ? 1 : 0}`;
 }
 
-function buildMainStatField(
-  rule: HsfRule,
-  index: number,
-  cb: RuleEditorCallbacks,
-  signal: AbortSignal,
-): HTMLElement {
+function buildMainStatField(rule: HsfRule): HTMLElement {
   const field = document.createElement("div");
   field.className = "edit-field";
 
@@ -358,6 +520,7 @@ function buildMainStatField(
   field.appendChild(label);
 
   const select = document.createElement("select");
+  select.dataset.field = "main-stat";
 
   const noneOpt = document.createElement("option");
   noneOpt.value = "-1";
@@ -372,38 +535,19 @@ function buildMainStatField(
   }
   select.value = encodeMainStat(rule);
 
-  select.addEventListener("change", () => {
-    const val = select.value;
-    if (val === "-1") {
-      rule.MainStatID = -1;
-      rule.MainStatF = 1;
-    } else {
-      const [statId, flatFlag] = val.split(":").map(Number);
-      rule.MainStatID = statId;
-      rule.MainStatF = flatFlag === 1 ? 0 : 1; // flatFlag=1 → isFlat → MainStatF=0
-    }
-    cb.onRuleChange(index, rule);
-  }, { signal });
-
   field.appendChild(select);
   return field;
 }
 
 // ---------------------------------------------------------------------------
-// Set selector — searchable checklist dropdown (like generator)
+// Set selector
 // ---------------------------------------------------------------------------
 
-/** Sorted set entries — built once, reused across all cards. */
 const SORTED_SET_ENTRIES = Object.entries(ARTIFACT_SET_NAMES)
   .map(([id, name]) => ({ id: Number(id), name }))
   .sort((a, b) => a.name.localeCompare(b.name));
 
-function buildSetField(
-  rule: HsfRule,
-  index: number,
-  cb: RuleEditorCallbacks,
-  signal: AbortSignal,
-): HTMLElement {
+function buildSetField(rule: HsfRule): HTMLElement {
   const field = document.createElement("div");
   field.className = "edit-field";
   field.style.gridColumn = "1 / -1";
@@ -420,50 +564,27 @@ function buildSetField(
   toggle.type = "button";
   toggle.className = "set-selector-toggle";
   toggle.textContent = summariseSets(rule.ArtifactSet ?? []);
+  toggle.dataset.action = "set-toggle";
   dropdown.appendChild(toggle);
 
   const panel = document.createElement("div");
   panel.className = "set-selector-panel";
   dropdown.appendChild(panel);
 
-  // Lazy-build the checkbox list on first open to avoid ~210 DOM elements
-  // per card sitting in memory for cards the user never expands.
-  let populated = false;
-
-  toggle.addEventListener("click", () => {
-    if (!populated) {
-      populateSetPanel(panel, rule, index, toggle, cb, signal);
-      populated = true;
-    }
-    panel.classList.toggle("open");
-    if (panel.classList.contains("open")) {
-      const search = panel.querySelector<HTMLInputElement>(".set-selector-search");
-      if (search) search.focus();
-    }
-  }, { signal });
-
   field.appendChild(dropdown);
   return field;
 }
 
-function populateSetPanel(
-  panel: HTMLElement,
-  rule: HsfRule,
-  index: number,
-  toggle: HTMLElement,
-  cb: RuleEditorCallbacks,
-  signal: AbortSignal,
-): void {
+function populateSetPanel(panel: HTMLElement, currentSets: number[]): void {
   const search = document.createElement("input");
   search.type = "text";
   search.className = "set-selector-search";
   search.placeholder = "Search sets\u2026";
+  search.dataset.action = "set-search";
   panel.appendChild(search);
 
   const list = document.createElement("div");
   list.className = "set-selector-list";
-
-  const currentSets = rule.ArtifactSet ?? [];
 
   for (const entry of SORTED_SET_ENTRIES) {
     const row = document.createElement("label");
@@ -473,17 +594,8 @@ function populateSetPanel(
     checkbox.type = "checkbox";
     checkbox.value = String(entry.id);
     checkbox.checked = currentSets.includes(entry.id);
-    checkbox.addEventListener("change", () => {
-      let sets = rule.ArtifactSet ?? [];
-      if (checkbox.checked) {
-        sets.push(entry.id);
-      } else {
-        sets = sets.filter((s) => s !== entry.id);
-      }
-      rule.ArtifactSet = sets.length > 0 ? sets : undefined;
-      toggle.textContent = summariseSets(sets);
-      cb.onRuleChange(index, rule);
-    }, { signal });
+    checkbox.dataset.action = "set-check";
+    checkbox.dataset.setId = String(entry.id);
     row.appendChild(checkbox);
 
     const span = document.createElement("span");
@@ -494,14 +606,6 @@ function populateSetPanel(
   }
 
   panel.appendChild(list);
-
-  search.addEventListener("input", () => {
-    const q = search.value.toLowerCase();
-    for (const item of list.children) {
-      const text = (item as HTMLElement).textContent!.toLowerCase();
-      (item as HTMLElement).hidden = !text.includes(q);
-    }
-  }, { signal });
 }
 
 function summariseSets(ids: number[]): string {
@@ -515,15 +619,10 @@ function summariseSets(ids: number[]): string {
 }
 
 // ---------------------------------------------------------------------------
-// Slot selector — checkbox grid
+// Slot selector
 // ---------------------------------------------------------------------------
 
-function buildSlotField(
-  rule: HsfRule,
-  index: number,
-  cb: RuleEditorCallbacks,
-  signal: AbortSignal,
-): HTMLElement {
+function buildSlotField(rule: HsfRule): HTMLElement {
   const field = document.createElement("div");
   field.className = "edit-field";
   field.style.gridColumn = "1 / -1";
@@ -548,16 +647,8 @@ function buildSlotField(
     checkbox.type = "checkbox";
     checkbox.value = String(id);
     checkbox.checked = currentSlots.includes(id);
-    checkbox.addEventListener("change", () => {
-      let slots = rule.ArtifactType ?? [];
-      if (checkbox.checked) {
-        slots.push(id);
-      } else {
-        slots = slots.filter((s) => s !== id);
-      }
-      rule.ArtifactType = slots.length > 0 ? slots : undefined;
-      cb.onRuleChange(index, rule);
-    }, { signal });
+    checkbox.dataset.action = "slot-check";
+    checkbox.dataset.slotId = String(id);
     lbl.appendChild(checkbox);
 
     const span = document.createElement("span");
@@ -575,12 +666,7 @@ function buildSlotField(
 // Substats section
 // ---------------------------------------------------------------------------
 
-function buildSubstatsSection(
-  rule: HsfRule,
-  index: number,
-  cb: RuleEditorCallbacks,
-  signal: AbortSignal,
-): HTMLElement {
+function buildSubstatsSection(rule: HsfRule): HTMLElement {
   const section = document.createElement("div");
   section.className = "edit-substats";
 
@@ -590,7 +676,7 @@ function buildSubstatsSection(
   section.appendChild(title);
 
   for (let i = 0; i < 4; i++) {
-    section.appendChild(buildSubstatRow(rule, i, index, cb, signal));
+    section.appendChild(buildSubstatRow(rule, i));
   }
 
   return section;
@@ -601,15 +687,10 @@ function encodeSubstatValue(s: HsfSubstat): string {
   return `${s.ID}:${s.IsFlat ? 1 : 0}`;
 }
 
-function buildSubstatRow(
-  rule: HsfRule,
-  subIndex: number,
-  ruleIndex: number,
-  cb: RuleEditorCallbacks,
-  signal: AbortSignal,
-): HTMLElement {
+function buildSubstatRow(rule: HsfRule, subIndex: number): HTMLElement {
   const row = document.createElement("div");
   row.className = "edit-substat-row";
+  row.dataset.subIndex = String(subIndex);
   const sub = rule.Substats[subIndex];
 
   // Stat dropdown
@@ -650,47 +731,6 @@ function buildSubstatRow(
   const isNone = sub.ID === -1;
   condSelect.disabled = isNone;
   valueInput.disabled = isNone;
-
-  // Wire events
-  statSelect.addEventListener("change", () => {
-    const val = statSelect.value;
-    if (val === "-1") {
-      rule.Substats[subIndex] = emptySubstat();
-      condSelect.disabled = true;
-      valueInput.disabled = true;
-      condSelect.value = ">=";
-      valueInput.value = "0";
-    } else {
-      const [statId, flatFlag] = val.split(":").map(Number);
-      rule.Substats[subIndex] = {
-        ...rule.Substats[subIndex],
-        ID: statId,
-        IsFlat: flatFlag === 1,
-        NotAvailable: false,
-        Condition: condSelect.value || ">=",
-        Value: Number(valueInput.value) || 0,
-      };
-      condSelect.disabled = false;
-      valueInput.disabled = false;
-    }
-    cb.onRuleChange(ruleIndex, rule);
-  }, { signal });
-
-  condSelect.addEventListener("change", () => {
-    rule.Substats[subIndex] = {
-      ...rule.Substats[subIndex],
-      Condition: condSelect.value,
-    };
-    cb.onRuleChange(ruleIndex, rule);
-  }, { signal });
-
-  valueInput.addEventListener("input", () => {
-    rule.Substats[subIndex] = {
-      ...rule.Substats[subIndex],
-      Value: Number(valueInput.value) || 0,
-    };
-    cb.onRuleChange(ruleIndex, rule);
-  }, { signal });
 
   row.appendChild(statSelect);
   row.appendChild(condSelect);

--- a/packages/web/src/editor.ts
+++ b/packages/web/src/editor.ts
@@ -475,10 +475,11 @@ function buildSetField(
 function summariseSets(ids: number[]): string {
   const filtered = ids.filter((id) => id !== 0);
   if (filtered.length === 0) return "Any set";
-  if (filtered.length <= 3) {
-    return filtered.map((id) => ARTIFACT_SET_NAMES[id] ?? `Unknown(${id})`).join(", ");
-  }
-  return `${filtered.length} sets selected`;
+  const names = filtered
+    .map((id) => ARTIFACT_SET_NAMES[id] ?? `Unknown(${id})`)
+    .sort((a, b) => a.localeCompare(b));
+  if (names.length <= 4) return names.join(", ");
+  return `${names.slice(0, 4).join(", ")}, \u2026 (${names.length} sets)`;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/web/src/editor.ts
+++ b/packages/web/src/editor.ts
@@ -9,7 +9,7 @@ import {
   FACTION_NAMES,
   emptySubstat,
 } from "@rslh/core";
-import { esc } from "./render.js";
+import { esc, renderPaginatedCards } from "./render.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -59,15 +59,14 @@ export function renderEditableRules(
   filter: HsfFilter,
   callbacks: RuleEditorCallbacks,
 ): void {
-  const container = document.getElementById("rules-container")!;
-  container.innerHTML = "";
-
   const total = filter.Rules.length;
-  filter.Rules.forEach((rule, i) => {
-    container.appendChild(buildEditableRuleCard(rule, i, total, callbacks));
-  });
+  renderPaginatedCards(
+    filter,
+    (rule, i) => buildEditableRuleCard(rule, i, total, callbacks),
+  );
 
   // Container-level drop indicator cleanup
+  const container = document.getElementById("rules-container")!;
   container.addEventListener("dragleave", (e) => {
     if (!container.contains(e.relatedTarget as Node)) {
       clearDropIndicators(container);

--- a/packages/web/src/editor.ts
+++ b/packages/web/src/editor.ts
@@ -55,6 +55,15 @@ function clearDropIndicators(container: Element): void {
 // Public API
 // ---------------------------------------------------------------------------
 
+// Single dragleave handler for the rules container — registered once to
+// avoid accumulating listeners on every renderEditableRules call.
+function handleContainerDragLeave(e: DragEvent): void {
+  const container = document.getElementById("rules-container")!;
+  if (!container.contains(e.relatedTarget as Node)) {
+    clearDropIndicators(container);
+  }
+}
+
 export function renderEditableRules(
   filter: HsfFilter,
   callbacks: RuleEditorCallbacks,
@@ -65,13 +74,10 @@ export function renderEditableRules(
     (rule, i) => buildEditableRuleCard(rule, i, total, callbacks),
   );
 
-  // Container-level drop indicator cleanup
+  // Container-level drop indicator cleanup — same function reference so
+  // addEventListener is a no-op if already registered.
   const container = document.getElementById("rules-container")!;
-  container.addEventListener("dragleave", (e) => {
-    if (!container.contains(e.relatedTarget as Node)) {
-      clearDropIndicators(container);
-    }
-  });
+  container.addEventListener("dragleave", handleContainerDragLeave);
 }
 
 export function clearEditor(): void {

--- a/packages/web/src/editor.ts
+++ b/packages/web/src/editor.ts
@@ -9,7 +9,7 @@ import {
   FACTION_NAMES,
   emptySubstat,
 } from "@rslh/core";
-import { esc, renderPaginatedCards } from "./render.js";
+import { abortPageListeners, esc, renderPaginatedCards } from "./render.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -71,7 +71,7 @@ export function renderEditableRules(
   const total = filter.Rules.length;
   renderPaginatedCards(
     filter,
-    (rule, i) => buildEditableRuleCard(rule, i, total, callbacks),
+    (rule, i, signal) => buildEditableRuleCard(rule, i, total, callbacks, signal),
   );
 
   // Container-level drop indicator cleanup — same function reference so
@@ -81,6 +81,7 @@ export function renderEditableRules(
 }
 
 export function clearEditor(): void {
+  abortPageListeners();
   document.getElementById("rules-container")!.innerHTML = "";
 }
 
@@ -93,6 +94,7 @@ function buildEditableRuleCard(
   index: number,
   total: number,
   cb: RuleEditorCallbacks,
+  signal: AbortSignal,
 ): HTMLElement {
   const card = document.createElement("div");
   card.className = "edit-card";
@@ -108,14 +110,14 @@ function buildEditableRuleCard(
     e.dataTransfer!.effectAllowed = "move";
     e.dataTransfer!.setData("text/plain", String(index));
     card.classList.add("edit-card-dragging");
-  });
+  }, { signal });
 
   card.addEventListener("dragend", () => {
     card.classList.remove("edit-card-dragging");
     dragSourceIndex = -1;
     const container = card.parentElement;
     if (container) clearDropIndicators(container);
-  });
+  }, { signal });
 
   card.addEventListener("dragover", (e) => {
     if (dragSourceIndex === -1) return;
@@ -135,7 +137,7 @@ function buildEditableRuleCard(
     } else {
       card.classList.add("edit-drop-below");
     }
-  });
+  }, { signal });
 
   card.addEventListener("drop", (e) => {
     e.preventDefault();
@@ -152,7 +154,7 @@ function buildEditableRuleCard(
     // removes the source first, shifting indices down by 1
     if (from < to) to--;
     if (from !== to) cb.onRuleMove(from, to);
-  });
+  }, { signal });
 
   // --- Header ---
   const header = document.createElement("div");
@@ -182,7 +184,7 @@ function buildEditableRuleCard(
     card.classList.toggle("keep", rule.Keep);
     card.classList.toggle("sell", !rule.Keep);
     cb.onRuleChange(index, rule);
-  });
+  }, { signal });
   header.appendChild(keepBtn);
 
   // Active/Inactive toggle
@@ -196,7 +198,7 @@ function buildEditableRuleCard(
     useBtn.className = `edit-badge-toggle ${rule.Use ? "badge-active" : "badge-inactive"}`;
     card.classList.toggle("inactive", !rule.Use);
     cb.onRuleChange(index, rule);
-  });
+  }, { signal });
   header.appendChild(useBtn);
 
   // Move up
@@ -206,7 +208,7 @@ function buildEditableRuleCard(
   upBtn.textContent = "\u25b2";
   upBtn.title = "Move up";
   upBtn.disabled = index === 0;
-  upBtn.addEventListener("click", () => cb.onRuleMove(index, index - 1));
+  upBtn.addEventListener("click", () => cb.onRuleMove(index, index - 1), { signal });
   header.appendChild(upBtn);
 
   // Move down
@@ -216,7 +218,7 @@ function buildEditableRuleCard(
   downBtn.textContent = "\u25bc";
   downBtn.title = "Move down";
   downBtn.disabled = index === total - 1;
-  downBtn.addEventListener("click", () => cb.onRuleMove(index, index + 1));
+  downBtn.addEventListener("click", () => cb.onRuleMove(index, index + 1), { signal });
   header.appendChild(downBtn);
 
   // Delete
@@ -225,7 +227,7 @@ function buildEditableRuleCard(
   delBtn.className = "edit-delete-btn";
   delBtn.textContent = "\u00d7";
   delBtn.title = "Delete rule";
-  delBtn.addEventListener("click", () => cb.onRuleDelete(index));
+  delBtn.addEventListener("click", () => cb.onRuleDelete(index), { signal });
   header.appendChild(delBtn);
 
   card.appendChild(header);
@@ -235,10 +237,10 @@ function buildEditableRuleCard(
   body.className = "edit-body";
 
   // Sets — searchable multi-select dropdown (reuse pattern from generator)
-  body.appendChild(buildSetField(rule, index, cb));
+  body.appendChild(buildSetField(rule, index, cb, signal));
 
   // Slots — checkbox grid
-  body.appendChild(buildSlotField(rule, index, cb));
+  body.appendChild(buildSlotField(rule, index, cb, signal));
 
   // Rank dropdown
   body.appendChild(
@@ -249,7 +251,7 @@ function buildEditableRuleCard(
     ], (val) => {
       rule.Rank = val;
       cb.onRuleChange(index, rule);
-    }),
+    }, signal),
   );
 
   // Rarity dropdown
@@ -261,11 +263,11 @@ function buildEditableRuleCard(
     buildSelectField("Rarity", rule.Rarity, rarityOpts, (val) => {
       rule.Rarity = val;
       cb.onRuleChange(index, rule);
-    }),
+    }, signal),
   );
 
   // Main Stat dropdown — encodes both MainStatID and MainStatF
-  body.appendChild(buildMainStatField(rule, index, cb));
+  body.appendChild(buildMainStatField(rule, index, cb, signal));
 
   // Level dropdown
   const levelOpts = Array.from({ length: 17 }, (_, i) => ({ value: i, label: String(i) }));
@@ -273,7 +275,7 @@ function buildEditableRuleCard(
     buildSelectField("Level", rule.LVLForCheck, levelOpts, (val) => {
       rule.LVLForCheck = val;
       cb.onRuleChange(index, rule);
-    }),
+    }, signal),
   );
 
   // Faction dropdown
@@ -285,13 +287,13 @@ function buildEditableRuleCard(
     buildSelectField("Faction", rule.Faction, factionOpts, (val) => {
       rule.Faction = val;
       cb.onRuleChange(index, rule);
-    }),
+    }, signal),
   );
 
   card.appendChild(body);
 
   // --- Substats ---
-  card.appendChild(buildSubstatsSection(rule, index, cb));
+  card.appendChild(buildSubstatsSection(rule, index, cb, signal));
 
   return card;
 }
@@ -305,6 +307,7 @@ function buildSelectField(
   current: number,
   options: { value: number; label: string }[],
   onChange: (value: number) => void,
+  signal: AbortSignal,
 ): HTMLElement {
   const field = document.createElement("div");
   field.className = "edit-field";
@@ -321,7 +324,7 @@ function buildSelectField(
     if (opt.value === current) option.selected = true;
     select.appendChild(option);
   }
-  select.addEventListener("change", () => onChange(Number(select.value)));
+  select.addEventListener("change", () => onChange(Number(select.value)), { signal });
   field.appendChild(select);
 
   return field;
@@ -345,6 +348,7 @@ function buildMainStatField(
   rule: HsfRule,
   index: number,
   cb: RuleEditorCallbacks,
+  signal: AbortSignal,
 ): HTMLElement {
   const field = document.createElement("div");
   field.className = "edit-field";
@@ -379,7 +383,7 @@ function buildMainStatField(
       rule.MainStatF = flatFlag === 1 ? 0 : 1; // flatFlag=1 → isFlat → MainStatF=0
     }
     cb.onRuleChange(index, rule);
-  });
+  }, { signal });
 
   field.appendChild(select);
   return field;
@@ -398,6 +402,7 @@ function buildSetField(
   rule: HsfRule,
   index: number,
   cb: RuleEditorCallbacks,
+  signal: AbortSignal,
 ): HTMLElement {
   const field = document.createElement("div");
   field.className = "edit-field";
@@ -427,7 +432,7 @@ function buildSetField(
 
   toggle.addEventListener("click", () => {
     if (!populated) {
-      populateSetPanel(panel, rule, index, toggle, cb);
+      populateSetPanel(panel, rule, index, toggle, cb, signal);
       populated = true;
     }
     panel.classList.toggle("open");
@@ -435,7 +440,7 @@ function buildSetField(
       const search = panel.querySelector<HTMLInputElement>(".set-selector-search");
       if (search) search.focus();
     }
-  });
+  }, { signal });
 
   field.appendChild(dropdown);
   return field;
@@ -447,6 +452,7 @@ function populateSetPanel(
   index: number,
   toggle: HTMLElement,
   cb: RuleEditorCallbacks,
+  signal: AbortSignal,
 ): void {
   const search = document.createElement("input");
   search.type = "text";
@@ -477,7 +483,7 @@ function populateSetPanel(
       rule.ArtifactSet = sets.length > 0 ? sets : undefined;
       toggle.textContent = summariseSets(sets);
       cb.onRuleChange(index, rule);
-    });
+    }, { signal });
     row.appendChild(checkbox);
 
     const span = document.createElement("span");
@@ -495,7 +501,7 @@ function populateSetPanel(
       const text = (item as HTMLElement).textContent!.toLowerCase();
       (item as HTMLElement).hidden = !text.includes(q);
     }
-  });
+  }, { signal });
 }
 
 function summariseSets(ids: number[]): string {
@@ -516,6 +522,7 @@ function buildSlotField(
   rule: HsfRule,
   index: number,
   cb: RuleEditorCallbacks,
+  signal: AbortSignal,
 ): HTMLElement {
   const field = document.createElement("div");
   field.className = "edit-field";
@@ -550,7 +557,7 @@ function buildSlotField(
       }
       rule.ArtifactType = slots.length > 0 ? slots : undefined;
       cb.onRuleChange(index, rule);
-    });
+    }, { signal });
     lbl.appendChild(checkbox);
 
     const span = document.createElement("span");
@@ -572,6 +579,7 @@ function buildSubstatsSection(
   rule: HsfRule,
   index: number,
   cb: RuleEditorCallbacks,
+  signal: AbortSignal,
 ): HTMLElement {
   const section = document.createElement("div");
   section.className = "edit-substats";
@@ -582,7 +590,7 @@ function buildSubstatsSection(
   section.appendChild(title);
 
   for (let i = 0; i < 4; i++) {
-    section.appendChild(buildSubstatRow(rule, i, index, cb));
+    section.appendChild(buildSubstatRow(rule, i, index, cb, signal));
   }
 
   return section;
@@ -598,6 +606,7 @@ function buildSubstatRow(
   subIndex: number,
   ruleIndex: number,
   cb: RuleEditorCallbacks,
+  signal: AbortSignal,
 ): HTMLElement {
   const row = document.createElement("div");
   row.className = "edit-substat-row";
@@ -665,7 +674,7 @@ function buildSubstatRow(
       valueInput.disabled = false;
     }
     cb.onRuleChange(ruleIndex, rule);
-  });
+  }, { signal });
 
   condSelect.addEventListener("change", () => {
     rule.Substats[subIndex] = {
@@ -673,7 +682,7 @@ function buildSubstatRow(
       Condition: condSelect.value,
     };
     cb.onRuleChange(ruleIndex, rule);
-  });
+  }, { signal });
 
   valueInput.addEventListener("input", () => {
     rule.Substats[subIndex] = {
@@ -681,7 +690,7 @@ function buildSubstatRow(
       Value: Number(valueInput.value) || 0,
     };
     cb.onRuleChange(ruleIndex, rule);
-  });
+  }, { signal });
 
   row.appendChild(statSelect);
   row.appendChild(condSelect);

--- a/packages/web/src/editor.ts
+++ b/packages/web/src/editor.ts
@@ -389,6 +389,11 @@ function buildMainStatField(
 // Set selector — searchable checklist dropdown (like generator)
 // ---------------------------------------------------------------------------
 
+/** Sorted set entries — built once, reused across all cards. */
+const SORTED_SET_ENTRIES = Object.entries(ARTIFACT_SET_NAMES)
+  .map(([id, name]) => ({ id: Number(id), name }))
+  .sort((a, b) => a.name.localeCompare(b.name));
+
 function buildSetField(
   rule: HsfRule,
   index: number,
@@ -406,17 +411,43 @@ function buildSetField(
   dropdown.className = "set-selector";
   dropdown.style.flex = "1";
 
-  const currentSets = rule.ArtifactSet ?? [];
-
   const toggle = document.createElement("button");
   toggle.type = "button";
   toggle.className = "set-selector-toggle";
-  toggle.textContent = summariseSets(currentSets);
+  toggle.textContent = summariseSets(rule.ArtifactSet ?? []);
   dropdown.appendChild(toggle);
 
   const panel = document.createElement("div");
   panel.className = "set-selector-panel";
+  dropdown.appendChild(panel);
 
+  // Lazy-build the checkbox list on first open to avoid ~210 DOM elements
+  // per card sitting in memory for cards the user never expands.
+  let populated = false;
+
+  toggle.addEventListener("click", () => {
+    if (!populated) {
+      populateSetPanel(panel, rule, index, toggle, cb);
+      populated = true;
+    }
+    panel.classList.toggle("open");
+    if (panel.classList.contains("open")) {
+      const search = panel.querySelector<HTMLInputElement>(".set-selector-search");
+      if (search) search.focus();
+    }
+  });
+
+  field.appendChild(dropdown);
+  return field;
+}
+
+function populateSetPanel(
+  panel: HTMLElement,
+  rule: HsfRule,
+  index: number,
+  toggle: HTMLElement,
+  cb: RuleEditorCallbacks,
+): void {
   const search = document.createElement("input");
   search.type = "text";
   search.className = "set-selector-search";
@@ -426,11 +457,9 @@ function buildSetField(
   const list = document.createElement("div");
   list.className = "set-selector-list";
 
-  const entries = Object.entries(ARTIFACT_SET_NAMES)
-    .map(([id, name]) => ({ id: Number(id), name }))
-    .sort((a, b) => a.name.localeCompare(b.name));
+  const currentSets = rule.ArtifactSet ?? [];
 
-  for (const entry of entries) {
+  for (const entry of SORTED_SET_ENTRIES) {
     const row = document.createElement("label");
     row.className = "set-selector-item";
 
@@ -459,7 +488,6 @@ function buildSetField(
   }
 
   panel.appendChild(list);
-  dropdown.appendChild(panel);
 
   search.addEventListener("input", () => {
     const q = search.value.toLowerCase();
@@ -468,14 +496,6 @@ function buildSetField(
       (item as HTMLElement).hidden = !text.includes(q);
     }
   });
-
-  toggle.addEventListener("click", () => {
-    panel.classList.toggle("open");
-    if (panel.classList.contains("open")) search.focus();
-  });
-
-  field.appendChild(dropdown);
-  return field;
 }
 
 function summariseSets(ids: number[]): string {

--- a/packages/web/src/editor.ts
+++ b/packages/web/src/editor.ts
@@ -90,6 +90,7 @@ function buildEditableRuleCard(
 ): HTMLElement {
   const card = document.createElement("div");
   card.className = "edit-card";
+  card.id = `rule-${index + 1}`;
   card.dataset.ruleIndex = String(index);
   card.draggable = true;
   if (!rule.Use) card.classList.add("inactive");

--- a/packages/web/src/editor.ts
+++ b/packages/web/src/editor.ts
@@ -468,12 +468,6 @@ function buildSetField(
     if (panel.classList.contains("open")) search.focus();
   });
 
-  document.addEventListener("click", (e) => {
-    if (!dropdown.contains(e.target as Node)) {
-      panel.classList.remove("open");
-    }
-  });
-
   field.appendChild(dropdown);
   return field;
 }

--- a/packages/web/src/generator.ts
+++ b/packages/web/src/generator.ts
@@ -252,13 +252,6 @@ function buildSetSelector(group: SettingGroup, index: number, cb: GeneratorCallb
     if (panel.classList.contains("open")) search.focus();
   });
 
-  // Close panel on click outside
-  document.addEventListener("click", (e) => {
-    if (!dropdown.contains(e.target as Node)) {
-      panel.classList.remove("open");
-    }
-  });
-
   wrap.appendChild(dropdown);
   return wrap;
 }

--- a/packages/web/src/generator.ts
+++ b/packages/web/src/generator.ts
@@ -258,10 +258,11 @@ function buildSetSelector(group: SettingGroup, index: number, cb: GeneratorCallb
 
 function summariseSets(ids: number[]): string {
   if (ids.length === 0) return "Any set";
-  if (ids.length <= 3) {
-    return ids.map((id) => ARTIFACT_SET_NAMES[id] ?? `Unknown(${id})`).join(", ");
-  }
-  return `${ids.length} sets selected`;
+  const names = ids
+    .map((id) => ARTIFACT_SET_NAMES[id] ?? `Unknown(${id})`)
+    .sort((a, b) => a.localeCompare(b));
+  if (names.length <= 4) return names.join(", ");
+  return `${names.slice(0, 4).join(", ")}, \u2026 (${names.length} sets)`;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/web/src/main.ts
+++ b/packages/web/src/main.ts
@@ -10,7 +10,7 @@ import type { QuickGenState, QuickBlock } from "./quick-generator.js";
 import { getSettings } from "./settings.js";
 import type { TabType } from "./settings.js";
 import { encodeState, decodeState } from "./share.js";
-import { renderEditableRules } from "./editor.js";
+import { renderEditableRules, clearEditor } from "./editor.js";
 import { initSettingsModal } from "./settings-modal.js";
 import { marked } from "marked";
 import readme from "../../../README.md?raw";
@@ -366,6 +366,7 @@ function showViewerContent(tab: TabEntry): void {
       saveHsfBtn.hidden = true;
       addRuleBtn.hidden = true;
       cancelBtn.hidden = true;
+      clearEditor();
       renderTestPanel(tab.filter);
       renderRules(tab.filter);
     }

--- a/packages/web/src/main.ts
+++ b/packages/web/src/main.ts
@@ -1113,6 +1113,20 @@ backToTop.addEventListener("click", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Global close-on-click-outside for set-selector dropdowns
+// ---------------------------------------------------------------------------
+
+// Single listener replaces per-card document listeners in editor.ts and
+// generator.ts that previously leaked (one per card, never removed).
+document.addEventListener("click", (e) => {
+  for (const panel of document.querySelectorAll(".set-selector-panel.open")) {
+    if (!panel.closest(".set-selector")?.contains(e.target as Node)) {
+      panel.classList.remove("open");
+    }
+  }
+});
+
+// ---------------------------------------------------------------------------
 // Initialize
 // ---------------------------------------------------------------------------
 

--- a/packages/web/src/render.ts
+++ b/packages/web/src/render.ts
@@ -88,11 +88,18 @@ export function renderRules(filter: HsfFilter): void {
     container.appendChild(buildRuleCard(rule, i));
   });
 
-  // Raw JSON collapsible
+  // Raw JSON collapsible — lazy-populate on first open
   const details = document.getElementById("raw-json")!;
   details.hidden = false;
   const pre = details.querySelector("pre")!;
-  pre.textContent = JSON.stringify(filter, null, 2);
+  pre.textContent = "";
+  let rawPopulated = false;
+  details.addEventListener("toggle", () => {
+    if (details.open && !rawPopulated) {
+      pre.textContent = JSON.stringify(filter, null, 2);
+      rawPopulated = true;
+    }
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -152,11 +159,10 @@ function buildRuleCard(rule: HsfRule, index: number): HTMLElement {
     card.appendChild(substatsEl);
   }
 
-  // Raw JSON toggle
+  // Raw JSON toggle — lazy-populate on first click
   const rawPre = document.createElement("pre");
   rawPre.className = "rule-raw";
   rawPre.hidden = true;
-  rawPre.textContent = JSON.stringify(rule, null, 2);
   card.appendChild(rawPre);
 
   const rawBtn = document.createElement("button");
@@ -164,6 +170,9 @@ function buildRuleCard(rule: HsfRule, index: number): HTMLElement {
   rawBtn.textContent = "Raw";
   rawBtn.addEventListener("click", () => {
     rawPre.hidden = !rawPre.hidden;
+    if (!rawPre.hidden && !rawPre.textContent) {
+      rawPre.textContent = JSON.stringify(rule, null, 2);
+    }
     rawBtn.classList.toggle("badge-raw-active", !rawPre.hidden);
   });
   header.appendChild(rawBtn);

--- a/packages/web/src/render.ts
+++ b/packages/web/src/render.ts
@@ -207,7 +207,9 @@ function renderCurrentPage(): void {
     const el = document.getElementById(id)!;
     el.hidden = total <= pageSize; // hide if everything fits on one page
     el.innerHTML = "";
-    if (!el.hidden) {
+    if (el.hidden) {
+      el.className = "";
+    } else {
       renderPaginationControls(el, total, totalPages, id === "rules-pagination", signal);
     }
   }
@@ -688,7 +690,7 @@ function runTest(filter: HsfFilter): void {
   const cls = rule.Keep ? "test-result-keep" : "test-result-sell";
 
   resultEl.className = `test-result ${cls}`;
-  resultEl.innerHTML = `${action} &mdash; matched <a href="#" data-rule-index="${matchedIndex}">rule #${ruleNum}</a>`;
+  resultEl.innerHTML = `${action} &mdash; matched <a href="#">rule #${ruleNum}</a>`;
 
   // Wire the link to navigate to the correct page and highlight the card
   const link = resultEl.querySelector("a")!;

--- a/packages/web/src/render.ts
+++ b/packages/web/src/render.ts
@@ -91,11 +91,10 @@ const PAGE_SIZES = [50, 100, 250, 500, 1000];
 let currentPage = 0;
 let pageSize = 100;
 let currentFilter: HsfFilter | null = null;
+let currentCardBuilder: (rule: HsfRule, index: number) => HTMLElement = buildRuleCard;
 
 export function renderRules(filter: HsfFilter): void {
-  currentFilter = filter;
-  currentPage = 0;
-  renderCurrentPage();
+  renderPaginatedCards(filter, buildRuleCard, true);
 
   // Raw JSON collapsible — lazy-populate on first open
   const details = document.getElementById("raw-json")!;
@@ -109,6 +108,24 @@ export function renderRules(filter: HsfFilter): void {
       rawPopulated = true;
     }
   });
+}
+
+/**
+ * Set up paginated card rendering. Resets to page 0 when a new filter is
+ * loaded; preserves current page when re-rendering the same filter (e.g.
+ * after an edit-mode rule move/delete/add).
+ */
+export function renderPaginatedCards(
+  filter: HsfFilter,
+  cardBuilder: (rule: HsfRule, index: number) => HTMLElement,
+  resetPage = false,
+): void {
+  if (resetPage || filter !== currentFilter) {
+    currentPage = 0;
+  }
+  currentFilter = filter;
+  currentCardBuilder = cardBuilder;
+  renderCurrentPage();
 }
 
 /** Navigate to the page containing the given 0-based rule index and scroll to it. */
@@ -146,7 +163,7 @@ function renderCurrentPage(): void {
   const container = document.getElementById("rules-container")!;
   container.innerHTML = "";
   for (let i = start; i < end; i++) {
-    container.appendChild(buildRuleCard(rules[i], i));
+    container.appendChild(currentCardBuilder(rules[i], i));
   }
 
   // Render pagination controls (top and bottom)

--- a/packages/web/src/render.ts
+++ b/packages/web/src/render.ts
@@ -42,6 +42,7 @@ export function clearError(): void {
 export function clearViewer(): void {
   clearError();
   abortPageListeners();
+  document.getElementById("rules-container")!.removeEventListener("click", handleViewerClick);
   currentFilter = null;
   document.getElementById("filter-summary")!.hidden = true;
   document.getElementById("test-panel")!.hidden = true;
@@ -103,8 +104,8 @@ export function getCurrentFilter(): HsfFilter | null {
 // Aborted before each page render so detached DOM nodes become collectible.
 let pageController = new AbortController();
 
-/** Abort all event listeners registered on the current page's DOM nodes. */
-export function abortPageListeners(): void {
+/** Abort all event listeners registered on the current page's pagination controls. */
+function abortPageListeners(): void {
   pageController.abort();
 }
 
@@ -113,6 +114,10 @@ export function abortPageListeners(): void {
 let rawJsonToggleHandler: (() => void) | null = null;
 
 export function renderRules(filter: HsfFilter): void {
+  const container = document.getElementById("rules-container")!;
+  container.removeEventListener("click", handleViewerClick);
+  container.addEventListener("click", handleViewerClick);
+
   renderPaginatedCards(filter, buildRuleCard, true);
 
   // Raw JSON collapsible — lazy-populate on first open
@@ -312,6 +317,28 @@ function scrollToRulesTop(): void {
 }
 
 // ---------------------------------------------------------------------------
+// View-mode delegation — single click handler for raw toggle buttons
+// ---------------------------------------------------------------------------
+
+function handleViewerClick(e: MouseEvent): void {
+  const target = e.target as HTMLElement;
+  const rawBtn = target.closest<HTMLElement>('[data-action="raw-toggle"]');
+  if (!rawBtn) return;
+  const card = rawBtn.closest<HTMLElement>(".rule-card");
+  if (!card) return;
+  const rawPre = card.querySelector<HTMLPreElement>(".rule-raw");
+  if (!rawPre) return;
+  rawPre.hidden = !rawPre.hidden;
+  if (!rawPre.hidden && !rawPre.textContent) {
+    const idx = Number(rawBtn.dataset.ruleIndex);
+    if (currentFilter && idx >= 0 && idx < currentFilter.Rules.length) {
+      rawPre.textContent = JSON.stringify(currentFilter.Rules[idx], null, 2);
+    }
+  }
+  rawBtn.classList.toggle("badge-raw-active", !rawPre.hidden);
+}
+
+// ---------------------------------------------------------------------------
 // Card builder
 // ---------------------------------------------------------------------------
 
@@ -368,7 +395,7 @@ function buildRuleCard(rule: HsfRule, index: number): HTMLElement {
     card.appendChild(substatsEl);
   }
 
-  // Raw JSON toggle — lazy-populate on first click
+  // Raw JSON toggle — lazy-populate on first click (delegated via handleViewerClick)
   const rawPre = document.createElement("pre");
   rawPre.className = "rule-raw";
   rawPre.hidden = true;
@@ -377,13 +404,8 @@ function buildRuleCard(rule: HsfRule, index: number): HTMLElement {
   const rawBtn = document.createElement("button");
   rawBtn.className = "badge badge-raw";
   rawBtn.textContent = "Raw";
-  rawBtn.addEventListener("click", () => {
-    rawPre.hidden = !rawPre.hidden;
-    if (!rawPre.hidden && !rawPre.textContent) {
-      rawPre.textContent = JSON.stringify(rule, null, 2);
-    }
-    rawBtn.classList.toggle("badge-raw-active", !rawPre.hidden);
-  });
+  rawBtn.dataset.action = "raw-toggle";
+  rawBtn.dataset.ruleIndex = String(index);
   header.appendChild(rawBtn);
 
   return card;

--- a/packages/web/src/render.ts
+++ b/packages/web/src/render.ts
@@ -92,7 +92,12 @@ const PAGE_SIZES = [50, 100, 250, 500, 1000];
 let currentPage = 0;
 let pageSize = 100;
 let currentFilter: HsfFilter | null = null;
-let currentCardBuilder: (rule: HsfRule, index: number, signal: AbortSignal) => HTMLElement = buildRuleCard;
+let currentCardBuilder: (rule: HsfRule, index: number) => HTMLElement = buildRuleCard;
+
+/** Getter for the current filter — used by editor delegation handlers. */
+export function getCurrentFilter(): HsfFilter | null {
+  return currentFilter;
+}
 
 // AbortController for tearing down event listeners when pages change.
 // Aborted before each page render so detached DOM nodes become collectible.
@@ -137,7 +142,7 @@ export function renderRules(filter: HsfFilter): void {
  */
 export function renderPaginatedCards(
   filter: HsfFilter,
-  cardBuilder: (rule: HsfRule, index: number, signal: AbortSignal) => HTMLElement,
+  cardBuilder: (rule: HsfRule, index: number) => HTMLElement,
   resetPage = false,
 ): void {
   if (resetPage || filter !== currentFilter) {
@@ -189,7 +194,7 @@ function renderCurrentPage(): void {
   const container = document.getElementById("rules-container")!;
   container.innerHTML = "";
   for (let i = start; i < end; i++) {
-    container.appendChild(currentCardBuilder(rules[i], i, signal));
+    container.appendChild(currentCardBuilder(rules[i], i));
   }
 
   // Render pagination controls (top and bottom)
@@ -310,7 +315,7 @@ function scrollToRulesTop(): void {
 // Card builder
 // ---------------------------------------------------------------------------
 
-function buildRuleCard(rule: HsfRule, index: number, signal: AbortSignal): HTMLElement {
+function buildRuleCard(rule: HsfRule, index: number): HTMLElement {
   const card = document.createElement("div");
   card.className = "rule-card";
   card.id = `rule-${index + 1}`;
@@ -378,7 +383,7 @@ function buildRuleCard(rule: HsfRule, index: number, signal: AbortSignal): HTMLE
       rawPre.textContent = JSON.stringify(rule, null, 2);
     }
     rawBtn.classList.toggle("badge-raw-active", !rawPre.hidden);
-  }, { signal });
+  });
   header.appendChild(rawBtn);
 
   return card;

--- a/packages/web/src/render.ts
+++ b/packages/web/src/render.ts
@@ -41,6 +41,7 @@ export function clearError(): void {
 /** Reset all viewer content areas to their initial hidden/empty state. */
 export function clearViewer(): void {
   clearError();
+  abortPageListeners();
   currentFilter = null;
   document.getElementById("filter-summary")!.hidden = true;
   document.getElementById("test-panel")!.hidden = true;
@@ -91,7 +92,16 @@ const PAGE_SIZES = [50, 100, 250, 500, 1000];
 let currentPage = 0;
 let pageSize = 100;
 let currentFilter: HsfFilter | null = null;
-let currentCardBuilder: (rule: HsfRule, index: number) => HTMLElement = buildRuleCard;
+let currentCardBuilder: (rule: HsfRule, index: number, signal: AbortSignal) => HTMLElement = buildRuleCard;
+
+// AbortController for tearing down event listeners when pages change.
+// Aborted before each page render so detached DOM nodes become collectible.
+let pageController = new AbortController();
+
+/** Abort all event listeners registered on the current page's DOM nodes. */
+export function abortPageListeners(): void {
+  pageController.abort();
+}
 
 // Track the raw-json toggle handler so we can remove it before re-adding
 // (the <details> element persists across tab switches).
@@ -127,7 +137,7 @@ export function renderRules(filter: HsfFilter): void {
  */
 export function renderPaginatedCards(
   filter: HsfFilter,
-  cardBuilder: (rule: HsfRule, index: number) => HTMLElement,
+  cardBuilder: (rule: HsfRule, index: number, signal: AbortSignal) => HTMLElement,
   resetPage = false,
 ): void {
   if (resetPage || filter !== currentFilter) {
@@ -161,6 +171,12 @@ export function goToRule(ruleIndex: number): void {
 function renderCurrentPage(): void {
   if (!currentFilter) return;
 
+  // Tear down all event listeners from the previous page so that
+  // detached DOM nodes become eligible for garbage collection.
+  pageController.abort();
+  pageController = new AbortController();
+  const { signal } = pageController;
+
   const rules = currentFilter.Rules;
   const total = rules.length;
   const totalPages = Math.max(1, Math.ceil(total / pageSize));
@@ -173,7 +189,7 @@ function renderCurrentPage(): void {
   const container = document.getElementById("rules-container")!;
   container.innerHTML = "";
   for (let i = start; i < end; i++) {
-    container.appendChild(currentCardBuilder(rules[i], i));
+    container.appendChild(currentCardBuilder(rules[i], i, signal));
   }
 
   // Render pagination controls (top and bottom)
@@ -182,7 +198,7 @@ function renderCurrentPage(): void {
     el.hidden = total <= pageSize; // hide if everything fits on one page
     el.innerHTML = "";
     if (!el.hidden) {
-      renderPaginationControls(el, total, totalPages, id === "rules-pagination");
+      renderPaginationControls(el, total, totalPages, id === "rules-pagination", signal);
     }
   }
 }
@@ -192,6 +208,7 @@ function renderPaginationControls(
   totalRules: number,
   totalPages: number,
   includeGoTo: boolean,
+  signal: AbortSignal,
 ): void {
   container.className = "rules-pagination";
 
@@ -207,7 +224,7 @@ function renderPaginationControls(
       renderCurrentPage();
       scrollToRulesTop();
     }
-  });
+  }, { signal });
   container.appendChild(prevBtn);
 
   // Page indicator
@@ -230,7 +247,7 @@ function renderPaginationControls(
       renderCurrentPage();
       scrollToRulesTop();
     }
-  });
+  }, { signal });
   container.appendChild(nextBtn);
 
   // Page size selector
@@ -250,7 +267,7 @@ function renderPaginationControls(
     currentPage = 0;
     renderCurrentPage();
     scrollToRulesTop();
-  });
+  }, { signal });
   sizeLabel.appendChild(sizeSelect);
   container.appendChild(sizeLabel);
 
@@ -274,10 +291,10 @@ function renderPaginationControls(
       const num = Number(goInput.value);
       if (num >= 1 && num <= totalRules) goToRule(num - 1);
     };
-    goBtn.addEventListener("click", doGo);
+    goBtn.addEventListener("click", doGo, { signal });
     goInput.addEventListener("keydown", (e) => {
       if (e.key === "Enter") doGo();
-    });
+    }, { signal });
 
     goWrap.appendChild(goInput);
     goWrap.appendChild(goBtn);
@@ -293,7 +310,7 @@ function scrollToRulesTop(): void {
 // Card builder
 // ---------------------------------------------------------------------------
 
-function buildRuleCard(rule: HsfRule, index: number): HTMLElement {
+function buildRuleCard(rule: HsfRule, index: number, signal: AbortSignal): HTMLElement {
   const card = document.createElement("div");
   card.className = "rule-card";
   card.id = `rule-${index + 1}`;
@@ -361,7 +378,7 @@ function buildRuleCard(rule: HsfRule, index: number): HTMLElement {
       rawPre.textContent = JSON.stringify(rule, null, 2);
     }
     rawBtn.classList.toggle("badge-raw-active", !rawPre.hidden);
-  });
+  }, { signal });
   header.appendChild(rawBtn);
 
   return card;

--- a/packages/web/src/render.ts
+++ b/packages/web/src/render.ts
@@ -41,10 +41,17 @@ export function clearError(): void {
 /** Reset all viewer content areas to their initial hidden/empty state. */
 export function clearViewer(): void {
   clearError();
+  currentFilter = null;
   document.getElementById("filter-summary")!.hidden = true;
   document.getElementById("test-panel")!.hidden = true;
   document.getElementById("test-panel-body")!.innerHTML = "";
+  const pag = document.getElementById("rules-pagination")!;
+  pag.innerHTML = "";
+  pag.hidden = true;
   document.getElementById("rules-container")!.innerHTML = "";
+  const pagBot = document.getElementById("rules-pagination-bottom")!;
+  pagBot.innerHTML = "";
+  pagBot.hidden = true;
   const rawJson = document.getElementById("raw-json")!;
   rawJson.hidden = true;
   rawJson.querySelector("pre")!.textContent = "";
@@ -77,16 +84,18 @@ export function renderSummary(filter: HsfFilter, fileName: string): void {
 }
 
 // ---------------------------------------------------------------------------
-// Rules
+// Rules — paginated rendering
 // ---------------------------------------------------------------------------
 
-export function renderRules(filter: HsfFilter): void {
-  const container = document.getElementById("rules-container")!;
-  container.innerHTML = "";
+const PAGE_SIZES = [50, 100, 250, 500, 1000];
+let currentPage = 0;
+let pageSize = 100;
+let currentFilter: HsfFilter | null = null;
 
-  filter.Rules.forEach((rule, i) => {
-    container.appendChild(buildRuleCard(rule, i));
-  });
+export function renderRules(filter: HsfFilter): void {
+  currentFilter = filter;
+  currentPage = 0;
+  renderCurrentPage();
 
   // Raw JSON collapsible — lazy-populate on first open
   const details = document.getElementById("raw-json")!;
@@ -100,6 +109,157 @@ export function renderRules(filter: HsfFilter): void {
       rawPopulated = true;
     }
   });
+}
+
+/** Navigate to the page containing the given 0-based rule index and scroll to it. */
+export function goToRule(ruleIndex: number): void {
+  if (!currentFilter) return;
+  const total = currentFilter.Rules.length;
+  if (ruleIndex < 0 || ruleIndex >= total) return;
+  const targetPage = Math.floor(ruleIndex / pageSize);
+  if (targetPage !== currentPage) {
+    currentPage = targetPage;
+    renderCurrentPage();
+  }
+  // Scroll to the card after render
+  const ruleNum = ruleIndex + 1;
+  const card = document.getElementById(`rule-${ruleNum}`);
+  if (card) {
+    card.scrollIntoView({ behavior: "smooth", block: "center" });
+    // Brief highlight
+    card.classList.add("rule-matched");
+  }
+}
+
+function renderCurrentPage(): void {
+  if (!currentFilter) return;
+
+  const rules = currentFilter.Rules;
+  const total = rules.length;
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+  if (currentPage >= totalPages) currentPage = totalPages - 1;
+
+  const start = currentPage * pageSize;
+  const end = Math.min(start + pageSize, total);
+
+  // Render rule cards for this page
+  const container = document.getElementById("rules-container")!;
+  container.innerHTML = "";
+  for (let i = start; i < end; i++) {
+    container.appendChild(buildRuleCard(rules[i], i));
+  }
+
+  // Render pagination controls (top and bottom)
+  for (const id of ["rules-pagination", "rules-pagination-bottom"]) {
+    const el = document.getElementById(id)!;
+    el.hidden = total <= pageSize; // hide if everything fits on one page
+    el.innerHTML = "";
+    if (!el.hidden) {
+      renderPaginationControls(el, total, totalPages, id === "rules-pagination");
+    }
+  }
+}
+
+function renderPaginationControls(
+  container: HTMLElement,
+  totalRules: number,
+  totalPages: number,
+  includeGoTo: boolean,
+): void {
+  container.className = "rules-pagination";
+
+  // Prev button
+  const prevBtn = document.createElement("button");
+  prevBtn.type = "button";
+  prevBtn.className = "pagination-btn";
+  prevBtn.textContent = "\u25c0 Prev";
+  prevBtn.disabled = currentPage === 0;
+  prevBtn.addEventListener("click", () => {
+    if (currentPage > 0) {
+      currentPage--;
+      renderCurrentPage();
+      scrollToRulesTop();
+    }
+  });
+  container.appendChild(prevBtn);
+
+  // Page indicator
+  const info = document.createElement("span");
+  info.className = "pagination-info";
+  const start = currentPage * pageSize + 1;
+  const end = Math.min((currentPage + 1) * pageSize, totalRules);
+  info.textContent = `Rules ${start}\u2013${end} of ${totalRules} (page ${currentPage + 1}/${totalPages})`;
+  container.appendChild(info);
+
+  // Next button
+  const nextBtn = document.createElement("button");
+  nextBtn.type = "button";
+  nextBtn.className = "pagination-btn";
+  nextBtn.textContent = "Next \u25b6";
+  nextBtn.disabled = currentPage >= totalPages - 1;
+  nextBtn.addEventListener("click", () => {
+    if (currentPage < totalPages - 1) {
+      currentPage++;
+      renderCurrentPage();
+      scrollToRulesTop();
+    }
+  });
+  container.appendChild(nextBtn);
+
+  // Page size selector
+  const sizeLabel = document.createElement("label");
+  sizeLabel.className = "pagination-size";
+  sizeLabel.textContent = "Per page: ";
+  const sizeSelect = document.createElement("select");
+  for (const size of PAGE_SIZES) {
+    const opt = document.createElement("option");
+    opt.value = String(size);
+    opt.textContent = String(size);
+    if (size === pageSize) opt.selected = true;
+    sizeSelect.appendChild(opt);
+  }
+  sizeSelect.addEventListener("change", () => {
+    pageSize = Number(sizeSelect.value);
+    currentPage = 0;
+    renderCurrentPage();
+    scrollToRulesTop();
+  });
+  sizeLabel.appendChild(sizeSelect);
+  container.appendChild(sizeLabel);
+
+  // Go-to-rule input (top bar only)
+  if (includeGoTo) {
+    const goWrap = document.createElement("span");
+    goWrap.className = "pagination-goto";
+
+    const goInput = document.createElement("input");
+    goInput.type = "number";
+    goInput.min = "1";
+    goInput.max = String(totalRules);
+    goInput.placeholder = "Rule #";
+    goInput.className = "pagination-goto-input";
+
+    const goBtn = document.createElement("button");
+    goBtn.type = "button";
+    goBtn.className = "pagination-btn";
+    goBtn.textContent = "Go";
+    const doGo = () => {
+      const num = Number(goInput.value);
+      if (num >= 1 && num <= totalRules) goToRule(num - 1);
+    };
+    goBtn.addEventListener("click", doGo);
+    goInput.addEventListener("keydown", (e) => {
+      if (e.key === "Enter") doGo();
+    });
+
+    goWrap.appendChild(goInput);
+    goWrap.appendChild(goBtn);
+    container.appendChild(goWrap);
+  }
+}
+
+function scrollToRulesTop(): void {
+  document.getElementById("rules-pagination")?.scrollIntoView({ behavior: "smooth", block: "start" });
 }
 
 // ---------------------------------------------------------------------------
@@ -457,9 +617,12 @@ function runTest(filter: HsfFilter): void {
   const cls = rule.Keep ? "test-result-keep" : "test-result-sell";
 
   resultEl.className = `test-result ${cls}`;
-  resultEl.innerHTML = `${action} &mdash; matched <a href="#rule-${ruleNum}">rule #${ruleNum}</a>`;
+  resultEl.innerHTML = `${action} &mdash; matched <a href="#" data-rule-index="${matchedIndex}">rule #${ruleNum}</a>`;
 
-  // Highlight matched rule card
-  const card = document.getElementById(`rule-${ruleNum}`);
-  if (card) card.classList.add("rule-matched");
+  // Wire the link to navigate to the correct page and highlight the card
+  const link = resultEl.querySelector("a")!;
+  link.addEventListener("click", (e) => {
+    e.preventDefault();
+    goToRule(matchedIndex);
+  });
 }

--- a/packages/web/src/render.ts
+++ b/packages/web/src/render.ts
@@ -93,6 +93,10 @@ let pageSize = 100;
 let currentFilter: HsfFilter | null = null;
 let currentCardBuilder: (rule: HsfRule, index: number) => HTMLElement = buildRuleCard;
 
+// Track the raw-json toggle handler so we can remove it before re-adding
+// (the <details> element persists across tab switches).
+let rawJsonToggleHandler: (() => void) | null = null;
+
 export function renderRules(filter: HsfFilter): void {
   renderPaginatedCards(filter, buildRuleCard, true);
 
@@ -101,13 +105,19 @@ export function renderRules(filter: HsfFilter): void {
   details.hidden = false;
   const pre = details.querySelector("pre")!;
   pre.textContent = "";
-  let rawPopulated = false;
-  details.addEventListener("toggle", () => {
-    if (details.open && !rawPopulated) {
+
+  // Remove previous handler to avoid accumulating listeners
+  if (rawJsonToggleHandler) {
+    details.removeEventListener("toggle", rawJsonToggleHandler);
+  }
+  let populated = false;
+  rawJsonToggleHandler = () => {
+    if (details.open && !populated) {
       pre.textContent = JSON.stringify(filter, null, 2);
-      rawPopulated = true;
+      populated = true;
     }
-  });
+  };
+  details.addEventListener("toggle", rawJsonToggleHandler);
 }
 
 /**

--- a/packages/web/src/style.css
+++ b/packages/web/src/style.css
@@ -684,6 +684,81 @@ pre {
 }
 
 /* ---------------------------------------------------------------------------
+   Pagination controls
+--------------------------------------------------------------------------- */
+
+.rules-pagination {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0.5rem 0;
+  font-size: 0.85rem;
+}
+
+.pagination-btn {
+  padding: 0.25rem 0.6rem;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  background: #fff;
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+
+.pagination-btn:hover:not(:disabled) {
+  background: #f3f4f6;
+}
+
+.pagination-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.pagination-info {
+  color: #666;
+}
+
+.pagination-size {
+  color: #666;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.pagination-size select {
+  padding: 0.2rem 0.3rem;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  font-size: 0.85rem;
+}
+
+.pagination-goto {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  margin-left: auto;
+}
+
+.pagination-goto-input {
+  width: 5rem;
+  padding: 0.2rem 0.4rem;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  font-size: 0.85rem;
+}
+
+/* Hide spinner arrows on the goto input */
+.pagination-goto-input::-webkit-inner-spin-button,
+.pagination-goto-input::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.pagination-goto-input {
+  -moz-appearance: textfield;
+}
+
+/* ---------------------------------------------------------------------------
    Test panel
 --------------------------------------------------------------------------- */
 


### PR DESCRIPTION
## Summary

- Replace ~36 per-card `addEventListener` calls in edit mode with 8 delegated handlers on `#rules-container` (`click`, `change`, `input`, 4 drag events, `dragleave`)
- Replace the per-card raw JSON toggle listener in view mode with a single delegated click handler
- All card builder functions are now pure DOM construction with zero event listeners — detached DOM nodes have no inbound closure references and become immediately GC-collectible

## Background

Chrome performance traces showed each edit-mode page switch leaked ~97,707 DOM nodes and ~3,608 event listeners. The previous `AbortController` fix (b8569e9) properly removed listeners from event targets, but V8's shared closure context still retained references — each closure captured both DOM elements and `rule` objects (reachable via `currentFilter`), creating cross-heap reference cycles the GC couldn't break.

## Changes

- **`editor.ts`**: Complete refactor — delegation handlers use `data-action`, `data-field`, `data-sub-index`, `data-set-id`, `data-slot-id` attributes to identify targets and look up rules via `getCurrentFilter().Rules[index]`
- **`render.ts`**: Added `getCurrentFilter()` export, delegated view-mode raw toggle, made `abortPageListeners` private (only used for pagination controls)
- **`editor.test.ts`**: Fixed event bubbling (`{ bubbles: true }`), added 4 data-attribute tests

## Test plan

- [x] `npm run build` passes
- [x] `npm test` — 219 tests pass (21 editor tests including new delegation tests)
- [x] `npm run lint` clean
- [ ] Manual Chrome DevTools profiling: verify ~0 DOM node/listener growth across page switches

🤖 Generated with [Claude Code](https://claude.com/claude-code)