### PR TITLE
feat(analytics): per-faction accessory slot-balance

### DIFF
--- a/oracle/analytics/DESIGN.md
+++ b/oracle/analytics/DESIGN.md
@@ -231,14 +231,19 @@ All thresholds are parameters (§6); the human reviews the ranked lists.
 
 A second delete pass that evens **unequipped** inventory across slots, so the kept pool isn't
 dominated by the structurally over-supplied slots (Weapon/Shield from fixed mains; Amulet/Banner
-from the 17-faction split). Within each **family separately** — armor (6 slots) and accessories
-(3 slots) — it computes a per-slot cap = that family's **mean kept-unequipped** count, then deletes
-**worst-quality-first** down to the cap. Protections: equipped mules are excluded (not part of the
-unequipped pool); **invested** (💎 ascended / 🔹 glyphed) pieces are never trimmed; and the §3.5
-**keep-floor** still binds (no bucket drops below its floor). `balanceFactor` (§6) scales the cap —
-`<1` more aggressive, `>1` gentler, `0` disables. On the current snapshot this caps the tall armor
-slots (Helmet/Weapon/Shield) at ~269 and Amulet at ~578 — predominantly cutting Weapon/Shield —
-while the naturally-short slots (Gloves/Chest/Boots) are left untouched.
+from the 17-faction split). **Armor** (6 slots) is evened as one family. **Accessories** (3 slots)
+are evened **per faction**: ring/amulet/banner are faction-locked gear, so each faction is balanced
+against *its own* mean kept-unequipped count rather than the pooled accessory total — cross-faction
+totals are intentionally left alone (a faction with more usable champions keeps more accessories).
+The per-slot cap = the relevant pool's (armor family / per-faction accessory) **mean kept-unequipped**
+count, then deletes **worst-quality-first** down to the cap. Protections: equipped mules are excluded
+(not part of the unequipped pool); **invested** (💎 ascended / 🔹 glyphed) pieces are never trimmed;
+and the §3.5 **keep-floor** still binds (no bucket drops below its floor). `balanceFactor` (§6) scales
+the cap — `<1` more aggressive, `>1` gentler, `0` disables. On the current snapshot this caps the tall
+armor slots (Helmet/Weapon/Shield) at ~275 while leaving the short slots (Gloves/Chest/Boots) alone,
+and within each faction trims the oversupplied amulets/banners toward that faction's scarcer ring
+count. Because the keep-floor binds per faction × slot × set, heavily-multi-set factions stay somewhat
+lopsided — the floor, not the cap, is the binding constraint for tight per-faction parity.
 
 ## 4. Census (descriptive, no judgment)
 

--- a/oracle/analytics/__tests__/triage.test.mjs
+++ b/oracle/analytics/__tests__/triage.test.mjs
@@ -75,6 +75,24 @@ test("slot-balance protects invested pieces from trimming", () => {
   expect(res.find((r) => r.item.id === 999).verdict).toBe("keep");
 });
 
+test("slot-balance evens accessories per-faction, not across factions", () => {
+  const items = [];
+  // Faction 5: 30 Rings only; Faction 6: 30 Amulets only (both demanded set, rising quality).
+  // Cross-faction the pool is 30 rings + 30 amulets -> a faction-blind cap of 60/3=20 would keep 20
+  // each. Per-faction, each faction's 30 accessories cap at 30/3=10, so each kept slot drops to 10.
+  for (let i = 0; i < 30; i++) {
+    items.push(mk(100 + i, 7, 66, main(7, 2, false), [sub(2, false, 0.2 + i * 0.02)],
+      { isAccessory: true, faction: 5 }));
+    items.push(mk(200 + i, 8, 66, main(8, 6, false), [sub(2, false, 0.2 + i * 0.02)],
+      { isAccessory: true, faction: 6 }));
+  }
+  const res = triage(items);
+  const keptF5Ring = res.filter((r) => r.item.faction === 5 && r.item.slot === 7 && r.verdict === "keep");
+  const keptF6Amu = res.filter((r) => r.item.faction === 6 && r.item.slot === 8 && r.verdict === "keep");
+  expect(keptF5Ring.length).toBe(10); // per-faction cap = 30/3, NOT the cross-faction 60/3 = 20
+  expect(keptF6Amu.length).toBe(10);
+});
+
 test("upgrade tags under-leveled demanded gear, not leveled gear", () => {
   const crit = [sub(5, false), sub(6, false), sub(2, false)];
   const items = [

--- a/oracle/analytics/analyze.mjs
+++ b/oracle/analytics/analyze.mjs
@@ -103,13 +103,27 @@ P(`**Oversupplied low-quality** — below slot-percentile ${CUTS.deletePct}, abo
 for (const [k, n] of topGroups(junkArm, (s) => `${slotName(s.item.slot)} · ${setName(s.item.set)}`)) P(`- ${k}: ${n}`);
 P(``);
 P(`### Slot-balance trims (${balDel.length})`, ``);
-P(`Evens the **unequipped** pool worst-first within each family (equipped mules excluded; invested 💎/🔹 pieces and below-floor buckets protected) — tall slots capped at the family mean: ~${familyCap(ARMOR, balDel)}/slot armor, ~${familyCap(ACC, balDel)}/slot accessories. By slot:`, ``);
+P(`Evens the **unequipped** pool worst-first (equipped mules excluded; invested 💎/🔹 pieces and below-floor buckets protected). **Armor** is one family — tall slots capped at the family mean (~${familyCap(ARMOR, balDel)}/slot). **Accessories** are evened **per faction**: ring/amulet/banner balanced within each faction (faction-locked gear), cross-faction totals left alone. By slot:`, ``);
 for (const [k, n] of topGroups(balDel, (s) => slotName(s.item.slot), 9)) P(`- ${k}: ${n}`);
 P(``);
 P(`Resulting unequipped distribution (the evened pool):`, ``);
 P(`| Slot | unequipped | deleted | kept-unequipped |`, `|---|---|---|---|`);
 for (const slot of SLOTS) { const r = slotRow(slot); P(`| ${slotName(slot)} | ${r.uneq} | ${r.delUneq} | ${r.kept} |`); }
 P(``);
+
+// Per-faction accessory balance — kept-unequipped Ring/Amulet/Banner within each faction (the
+// pool the per-faction pass evens). A balanced faction reads roughly flat across the three.
+const accKept = (faction, slot) => scored.filter((s) => s.item.faction === faction
+  && s.item.slot === slot && s.verdict === "keep" && s.item.equippedChampId === 0).length;
+const accFactions = [...new Set(items.filter((i) => i.isAccessory).map((i) => i.faction))]
+  .sort((a, b) => a - b)
+  .filter((f) => ACC.some((slot) => accKept(f, slot) > 0));
+if (accFactions.length) {
+  P(`Per-faction accessory balance (kept-unequipped — each faction's ring/amulet/banner evened):`, ``);
+  P(`| Faction | Ring | Amulet | Banner |`, `|---|--:|--:|--:|`);
+  for (const f of accFactions) P(`| ${facName(f)} | ${accKept(f, 7)} | ${accKept(f, 8)} | ${accKept(f, 9)} |`);
+  P(``);
+}
 P(`### Spot-check — worst 50 deletes (worst first)`, ``);
 for (const s of deletes.slice().sort((a, b) => a.q.score - b.q.score).slice(0, 50)) {
   const it = s.item, fac = it.isAccessory ? ` ${facName(it.faction)}` : "";

--- a/oracle/analytics/triage.mjs
+++ b/oracle/analytics/triage.mjs
@@ -12,16 +12,44 @@ export function keepPremium(setId) {
   return demand + (demand >= 3 ? scarcity - 2 : 0);
 }
 
-// Count of kept UNEQUIPPED pieces in a slot (the pool the slot-balance pass evens out).
-function keptUnequippedInSlot(scored, slot) {
+// Count of kept UNEQUIPPED pieces in a slot (the pool the slot-balance pass evens out). When
+// `faction` is given, only that faction's pieces count (the per-faction accessory pass).
+function keptUnequippedInSlot(scored, slot, faction = null) {
   return scored.filter((s) => s.item.slot === slot
+    && (faction === null || s.item.faction === faction)
     && s.verdict === "keep" && s.item.equippedChampId === 0).length;
 }
 
-// Slot-balance: even the UNEQUIPPED pool within each slot family (armor / accessories) by deleting
-// worst-quality-first down to a per-family target (mean kept-unequipped x balanceFactor). Equipped
-// mules aren't part of the unequipped pool, and invested (ascended/glyphed) pieces and below-floor
-// buckets are protected. Mutates `scored`. (DESIGN.md §3.8)
+// Even one slot family (optionally restricted to a faction) toward its mean kept-unequipped count
+// (x balanceFactor), deleting worst-quality-first. Equipped mules aren't part of the pool; invested
+// (ascended/glyphed) pieces and below-floor buckets are protected. Mutates `scored` + `live`.
+function balanceFamily(scored, slots, live, faction = null) {
+  const kept = slots.reduce((n, sl) => n + keptUnequippedInSlot(scored, sl, faction), 0);
+  const cap = Math.round((kept / slots.length) * CUTS.balanceFactor);
+  const facTag = faction === null ? "" : ` (faction ${faction})`;
+  for (const slot of slots) {
+    let keptUneq = keptUnequippedInSlot(scored, slot, faction);
+    const pool = scored
+      .filter((s) => s.item.slot === slot && (faction === null || s.item.faction === faction)
+        && s.verdict === "keep" && s.item.equippedChampId === 0 && !s.inv.ascended && !s.inv.glyphed)
+      .sort((a, b) => a.q.score - b.q.score);
+    for (const s of pool) {
+      if (keptUneq <= cap) break;
+      const k = bucketKey(s.item);
+      if ((live.get(k) || 0) <= floorFor(s.item)) continue; // keep-floor protects spares
+      s.verdict = "delete";
+      s.slotBalanced = true;
+      s.reason = `slot-balance: oversupplied unequipped slot${facTag} (q${s.q.score}), trimmed worst-first toward ~${cap}`;
+      live.set(k, live.get(k) - 1);
+      keptUneq--;
+    }
+  }
+}
+
+// Slot-balance: even the UNEQUIPPED pool worst-quality-first. Armor (slots 1-6) is one family —
+// it isn't faction-locked. Accessories are evened PER FACTION: ring/amulet/banner are faction-bound
+// gear, so each faction's three slots are balanced against each other, while cross-faction totals are
+// left alone (a faction with more usable champions keeps more accessories). Mutates `scored`. (§3.8)
 export function slotBalance(scored, counts) {
   if (!CUTS.balanceFactor) return;
   // live unequipped count per bucket = static count minus unequipped deletes already taken.
@@ -32,27 +60,10 @@ export function slotBalance(scored, counts) {
       live.set(k, (live.get(k) || 0) - 1);
     }
   }
-  for (const slots of [ARMOR_SLOTS, ACC_SLOTS]) {
-    const kept = slots.reduce((n, sl) => n + keptUnequippedInSlot(scored, sl), 0);
-    const cap = Math.round((kept / slots.length) * CUTS.balanceFactor);
-    for (const slot of slots) {
-      let keptUneq = keptUnequippedInSlot(scored, slot);
-      const pool = scored
-        .filter((s) => s.item.slot === slot && s.verdict === "keep"
-          && s.item.equippedChampId === 0 && !s.inv.ascended && !s.inv.glyphed)
-        .sort((a, b) => a.q.score - b.q.score);
-      for (const s of pool) {
-        if (keptUneq <= cap) break;
-        const k = bucketKey(s.item);
-        if ((live.get(k) || 0) <= floorFor(s.item)) continue; // keep-floor protects spares
-        s.verdict = "delete";
-        s.slotBalanced = true;
-        s.reason = `slot-balance: oversupplied unequipped slot (q${s.q.score}), trimmed worst-first toward ~${cap}`;
-        live.set(k, live.get(k) - 1);
-        keptUneq--;
-      }
-    }
-  }
+  balanceFamily(scored, ARMOR_SLOTS, live);
+  const factions = [...new Set(scored.filter((s) => s.item.isAccessory).map((s) => s.item.faction))]
+    .sort((a, b) => a - b);
+  for (const faction of factions) balanceFamily(scored, ACC_SLOTS, live, faction);
 }
 
 function slotSortedScores(scored) {


### PR DESCRIPTION
## What

Make the accessory slot-balance pass run **per faction** instead of across the whole accessory pool. Ring/amulet/banner are faction-locked gear, so each faction's three slots should be balanced against each other (its own mean kept-unequipped), while **cross-faction totals are intentionally left alone** (a faction with more usable champions keeps more accessories). Armor stays one family — it isn't faction-locked.

## Changes

- **`triage.mjs`** — extract `balanceFamily(scored, slots, live, faction?)`. Armor runs once; the accessory pass loops per faction.
- **`analyze.mjs`** — report states accessories are evened per-faction and adds a **per-faction × slot kept-unequipped table** so the balance is visible.
- **`DESIGN.md §3.8`** — documents the per-faction rule and the keep-floor binding caveat.
- **`triage.test.mjs`** — TDD test: per-faction cap (10) differs from the old faction-blind cap (20). Existing single-faction balance tests stay green.

## Effect (06-18 snapshot)

Each faction is pulled toward parity — amulets/banners trimmed toward the always-scarcer ring count. Aggregate accessory deletes move only `854 → 875` (+21, mostly banners): the **keep-floor (≥4 per faction × slot × set) is the binding constraint**, not the cap, so heavily-multi-set factions stay somewhat lopsided (e.g. Dark Elves `20/34/28`). Tightening per-faction parity further would mean tuning the floor or `balanceFactor`, not the cap.

Gate: `npm run build && npm test && npm run lint` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)