### PR TITLE
chore: onboard repo to hivemind

### DIFF
--- a/.github/workflows/trust-label.yml
+++ b/.github/workflows/trust-label.yml
@@ -1,0 +1,33 @@
+name: Trust Label
+on:
+  issues:
+    types: [opened]
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: { permission } } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: context.payload.issue.user.login,
+            });
+            if (!['admin', 'write', 'maintain'].includes(permission)) return;
+
+            const labels = (context.payload.issue.labels || []).map(l => l.name);
+            const ACTIONABLE_TYPES = ['type:implement', 'type:release', 'type:research', 'type:needs-refinement'];
+            const hasActionableType = labels.some(l => ACTIONABLE_TYPES.includes(l));
+            const isBlocked = labels.includes('workflow:blocked');
+
+            if (hasActionableType && !isBlocked) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.issue.number,
+                labels: ['workflow:ready'],
+              });
+            }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,3 +39,30 @@ npm run dev          # start vite dev server for web UI
 ## Services
 
 - **Analytics dashboard:** https://rslh-filter-gen.goatcounter.com/ (GoatCounter, privacy-friendly, no cookies)
+
+## Build & Test
+
+- Build: `npm run build`
+- Test: `npm test`
+- Lint: `npm run lint`
+- Type check: covered by `npm run build` (tsc project references; no standalone script)
+- Format: N/A (no formatter configured)
+
+Run `npm run build && npm test && npm run lint` before every commit — there are no git hooks.
+
+## Hivemind
+
+This repo is managed by [hivemind](https://github.com/fumb13s/hivemind).
+
+### Development Workflow
+
+1. **Brainstorm** — use the `hivemind:brainstorm` skill to design issues
+2. **Coordinator picks it up** — issues labeled `workflow:ready` are claimed automatically
+3. **Plan → Implement → Review → Merge** — the coordinator drives the full lifecycle
+
+Do not create issues manually — always use the brainstorm skill.
+
+### Coordinator Management
+
+- Start: `hivemind --repo /path/to/this/repo [--max-workers N]`
+- Stop: Ctrl+C or SIGTERM


### PR DESCRIPTION
Completes hivemind onboarding for this repo. Steps 1–3, 5 and 6 of `setup-target.sh` were applied directly (labels, `.hivemind/` deploy, repo settings, branch protections); this PR carries the two changes that belong in git.

## What's here

- **`.github/workflows/trust-label.yml`** — labels an issue `workflow:ready` when its author has `admin`/`write`/`maintain` on the repo and it carries an actionable type label (`type:implement`, `type:release`, `type:research`, `type:needs-refinement`) and isn't `workflow:blocked`. Permission is read from GitHub at runtime; the current collaborator list is one account, so only the owner can auto-arm an issue. On a public repo this is what stops a drive-by issue from starting an autonomous run.
- **`CLAUDE.md`** — `## Build & Test` with the real verification commands (the setup script writes `<build command>` placeholders), plus the hivemind workflow notes.

## Applied outside this PR

- 26 workflow/phase/effort/type labels
- `.hivemind/` + `.claude/` deployment artifacts — **gitignored**, local only
- Repo settings: merge commits off, auto-delete branches on (squash title/body were already correct)
- Branch protection on `main`: required check **`build`**, strict, 1 review, dismiss stale, no force-push, no deletion, `enforce_admins: false`

## Note on the required check

`setup-branch-protections.sh` defaults the required context to `ci`, but GitHub status contexts come from job names — this repo's CI workflow is named "CI" with jobs `build` and `deploy-pages`, and only `build` runs on a PR. The default would have left every PR on a permanently pending check, so the protection was applied with `build` instead.

This PR is itself the end-to-end check that the context name is right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)