### PR TITLE
fix(analytics): close the speed solver's final review findings

### DIFF
--- a/docs/plans/2026-08-14-champion-speed-solver-design.md
+++ b/docs/plans/2026-08-14-champion-speed-solver-design.md
@@ -142,8 +142,13 @@ Expected shape:
 { "Kantra the Cyclone": 109, "Arbiter": 110 }
 ```
 
-Coverage against the 2026-08-12 snapshot is 457 of 476 geared champion names. The missing 19 require
+Coverage against the 2026-08-12 snapshot is 473 of 476 geared champion names. The missing 3 require
 `--base`, and their absence is a hard error naming that flag rather than a silent guess.
+
+That figure was 456 before `lookupBase` grew its punctuation fallback. The other 17 were never a
+dataset gap: the game spells champions with apostrophes, commas, colons and hyphens, and a corpus
+that has been through a slug or an OCR pass need not. Matching on the lowercased name alone hid
+champions the corpus already held.
 
 **`constant` is measured, once, per champion:**
 

--- a/oracle/analytics/README.md
+++ b/oracle/analytics/README.md
@@ -38,6 +38,11 @@ own database, and nothing is ever deleted.
    prints the N best builds instead of only the winner, so a runner-up that costs one point of
    speed but frees six pieces of a set is visible rather than discarded.
 
+   The vault it searches includes gear that is currently worn, since gear can be moved — so a build
+   is not usually a set of spare pieces. Each item that would have to come off someone is marked
+   `on <champion>`, and every build carries a line counting them. Solving several champions this way
+   proposes the same physical pieces to each, and those builds cannot all be worn at once.
+
    The corpus of champion base speeds is an external local dataset — pass `--corpus PATH` or set
    `$RSLH_SPEED_CORPUS`. `speed.mjs verify` reports the distribution of unexplained flat speed across
    every geared champion — the size of the gap between the model and observed speed, which is

--- a/oracle/analytics/__tests__/champs.test.mjs
+++ b/oracle/analytics/__tests__/champs.test.mjs
@@ -1,6 +1,6 @@
 // oracle/analytics/__tests__/champs.test.mjs
 import { test, expect } from "vitest";
-import { isRealChamp, parseArgs, selectChamps } from "../champs.mjs";
+import { isRealChamp, parseArgs, selectChamps, suggestNames } from "../champs.mjs";
 import * as gear from "../champion-gear.mjs";
 
 const champ = (o = {}) => ({ ID: 110, Name: "Elhain", Role: 0, Rarity: 3, Rang: 6, Lvl: 60,
@@ -34,6 +34,53 @@ test("selectChamps matches any other selector as a case-insensitive name substri
   const rows = [champ({ Name: "Elhain" }), champ({ Name: "Kael" })];
   expect(selectChamps(rows, "ELHA").map((r) => r.Name)).toEqual(["Elhain"]);
   expect(selectChamps(rows, null)).toHaveLength(2);
+});
+
+// --- suggestNames -----------------------------------------------------------
+
+// A prefix, not an edit distance: the realistic miss is a half-remembered or half-typed name, and
+// the opening characters are what the user is most likely to have right.
+// Skaeva contains "kae" but does not start with it. selectChamps already tried a substring match and
+// came back empty, so repeating it here would suggest names it has just ruled out.
+test("suggestNames offers names sharing the selector's first three characters", () => {
+  const rows = [champ({ Name: "Kael" }), champ({ Name: "Kaelan" }), champ({ Name: "Skaeva" }),
+    champ({ Name: "Elhain" })];
+  expect(suggestNames(rows, "kaelyn")).toEqual(["Kael", "Kaelan"]);
+  expect(suggestNames(rows, "KAE")).toEqual(["Kael", "Kaelan"]);
+  expect(suggestNames(rows, "elhian")).toEqual(["Elhain"]);
+});
+
+// Exactly three characters. Two would drag in every name sharing an opening syllable; four would
+// miss a typo IN the fourth character, which is at least as likely as one further along.
+test("suggestNames matches on a three-character prefix, not two or four", () => {
+  const rows = [champ({ Name: "Kaen" }), champ({ Name: "Kacper" }), champ({ Name: "Kaelan" })];
+  expect(suggestNames(rows, "kaelyn")).toEqual(["Kaen", "Kaelan"]);
+});
+
+// The roster holds one row per COPY, so a name with four copies would otherwise be suggested four
+// times and crowd the other candidates out of the list.
+test("suggestNames lists each name once however many copies exist", () => {
+  const rows = [champ({ ID: 1, Name: "Kael" }), champ({ ID: 2, Name: "Kael" }),
+    champ({ ID: 3, Name: "Kaelan" })];
+  expect(suggestNames(rows, "kae")).toEqual(["Kael", "Kaelan"]);
+});
+
+test("suggestNames caps the list at eight", () => {
+  const rows = Array.from({ length: 12 }, (_, i) => champ({ ID: i, Name: `Elhain ${i}` }));
+  expect(suggestNames(rows, "elhain")).toHaveLength(8);
+});
+
+test("suggestNames returns nothing when no name is close", () => {
+  expect(suggestNames([champ({ Name: "Kael" })], "zzz")).toEqual([]);
+  expect(suggestNames([], "kael")).toEqual([]);
+});
+
+// Both callers reach here with whatever the command line gave them, and an all-digit selector that
+// matched no ID arrives as a string of digits rather than a name.
+test("suggestNames tolerates a selector that is not a string", () => {
+  const rows = [champ({ Name: "Kael" })];
+  expect(suggestNames(rows, 110)).toEqual([]);
+  expect(suggestNames(rows, null)).toEqual([]);
 });
 
 // champion-gear.mjs is the historical home of these; keeping the re-export means its own tests and

--- a/oracle/analytics/__tests__/speed-cli.test.mjs
+++ b/oracle/analytics/__tests__/speed-cli.test.mjs
@@ -1,7 +1,8 @@
 // oracle/analytics/__tests__/speed-cli.test.mjs
 import { test, expect } from "vitest";
 import fc from "fast-check";
-import { describeSets, formatBuild, parseSpeedArgs, rankBuilds, topBuilds } from "../speed.mjs";
+import { describeSets, describeWearers, formatBuild, otherWearers, parseSpeedArgs, rankBuilds,
+  topBuilds } from "../speed.mjs";
 import { SLOTS, buildIndex, solve } from "../speed-solve.mjs";
 import { buildSpeed, speedOfWith } from "../speed-model.mjs";
 
@@ -137,14 +138,39 @@ const BUILD = { items: [BOOTS, HELM, WEAPON], counts: new Map([[4, 2]]), plan: [
 
 test("formatBuild prints the build slot by slot with the arithmetic that produced it", () => {
   // items 23 + 30 + 7 = 60; Speed x2 at base 100 = +12; 100 + 12 + 60 + 5 = 177.
-  const out = formatBuild({ ...BUILD, speed: 177 }, 100, 5, 0, new Map());
+  const out = formatBuild({ ...BUILD, speed: 177 }, 100, 5, 0, new Map(), new Map());
   expect(out.split("\n")).toEqual([
     "  177 SPD   Speed x2 (+12)",
     "    Helmet  Speed          +12   spd  30   #3",
     "    Boots   Speed          +16   spd  23   #7",
     "    Weapon  (setless)      + 8   spd   7   #5",
+    "    on other champions: none",
     "    base 100 + sets 12 + items 60 + constant 5 = 177",
   ]);
+});
+
+// Solving several champions against one vault proposes the same physical pieces to each, so a build
+// can be correct and still unbuildable without stripping other champions. That fact decides whether
+// the answer is actionable, and it is printed in both places a reader looks: beside the piece, and
+// once for the build.
+test("formatBuild marks each item that is on another champion, and counts them", () => {
+  const wearers = new Map([[3, "Kantra the Cyclone"], [7, "Kantra the Cyclone"], [5, "Elhain"]]);
+  const out = formatBuild({ ...BUILD, speed: 177 }, 100, 5, 0, new Map(), wearers);
+  expect(out.split("\n")).toEqual([
+    "  177 SPD   Speed x2 (+12)",
+    "    Helmet  Speed          +12   spd  30   #3   on Kantra the Cyclone",
+    "    Boots   Speed          +16   spd  23   #7   on Kantra the Cyclone",
+    "    Weapon  (setless)      + 8   spd   7   #5   on Elhain",
+    "    on other champions: 3 of 3 — Kantra the Cyclone x2, Elhain",
+    "    base 100 + sets 12 + items 60 + constant 5 = 177",
+  ]);
+});
+
+test("formatBuild leaves a free item unmarked and counts only the borrowed ones", () => {
+  const out = formatBuild({ ...BUILD, speed: 177 }, 100, 5, 0, new Map(), new Map([[7, "Elhain"]]));
+  expect(out).toContain("    Boots   Speed          +16   spd  23   #7   on Elhain");
+  expect(out).toContain("    Helmet  Speed          +12   spd  30   #3\n");
+  expect(out).toContain("    on other champions: 1 of 3 — Elhain");
 });
 
 // The glyph floor has to reach the per-item speeds AND stay under each rarity x rank ceiling, or the
@@ -152,12 +178,13 @@ test("formatBuild prints the build slot by slot with the arithmetic that produce
 test("formatBuild applies the glyph floor to each item, clamped to its rarity x rank ceiling", () => {
   const ceilings = new Map([["4|6", 6], ["3|5", 10]]);
   // Boots clamp 8 -> 6, so 20 + 6 = 26 (not 28); Weapon's ceiling is not binding, 7 + 8 = 15.
-  const out = formatBuild({ ...BUILD, speed: 188 }, 100, 5, 8, ceilings);
+  const out = formatBuild({ ...BUILD, speed: 188 }, 100, 5, 8, ceilings, new Map());
   expect(out.split("\n")).toEqual([
     "  188 SPD   Speed x2 (+12)",
     "    Helmet  Speed          +12   spd  30   #3",
     "    Boots   Speed          +16   spd  26   #7",
     "    Weapon  (setless)      + 8   spd  15   #5",
+    "    on other champions: none",
     "    base 100 + sets 12 + items 71 + constant 5 = 188",
   ]);
 });
@@ -167,7 +194,7 @@ test("formatBuild applies the glyph floor to each item, clamped to its rarity x 
 // solver reported, the line says so instead of absorbing the difference into the set term and
 // balancing anyway. Here the four terms make 177 against a solver total of 200.
 test("formatBuild reconciles against the solver's total and flags a disagreement", () => {
-  const out = formatBuild({ ...BUILD, speed: 200 }, 100, 5, 0, new Map());
+  const out = formatBuild({ ...BUILD, speed: 200 }, 100, 5, 0, new Map(), new Map());
   expect(out).toContain("base 100 + sets 12 + items 60 + constant 5 = 177");
   expect(out).toContain("MISMATCH: the solver said 200");
   // The header is computed from the same counts, so the two lines can no longer disagree with each
@@ -176,14 +203,74 @@ test("formatBuild reconciles against the solver's total and flags a disagreement
 });
 
 test("formatBuild stays quiet when the terms reconcile", () => {
-  expect(formatBuild({ ...BUILD, speed: 177 }, 100, 5, 0, new Map())).not.toContain("MISMATCH");
+  expect(formatBuild({ ...BUILD, speed: 177 }, 100, 5, 0, new Map(), new Map()))
+    .not.toContain("MISMATCH");
   expect(formatBuild({ ...BUILD, speed: 188 }, 100, 5, 8,
-    new Map([["4|6", 6], ["3|5", 10]]))).not.toContain("MISMATCH");
+    new Map([["4|6", 6], ["3|5", 10]]), new Map())).not.toContain("MISMATCH");
 });
 
 test("formatBuild handles a negative constant without losing the sign", () => {
-  const out = formatBuild({ ...BUILD, speed: 165 }, 100, -7, 0, new Map());
+  const out = formatBuild({ ...BUILD, speed: 165 }, 100, -7, 0, new Map(), new Map());
   expect(out).toContain("base 100 + sets 12 + items 60 + constant -7 = 165");
+});
+
+// --- otherWearers / describeWearers -----------------------------------------
+
+const ROWS = [{ ID: 11, Name: "Kantra the Cyclone" }, { ID: 22, Name: "Elhain" }];
+const worn = (id, champId) => item({ id, equippedChampId: champId });
+
+// Only pieces that have to come OFF someone. A free piece costs nothing to fit, and neither does one
+// already on the champion being solved for — reporting either would bury the pieces that do.
+test("otherWearers names the champion wearing each item, skipping free and own pieces", () => {
+  const items = [worn(1, 11), worn(2, 22), worn(3, 0), worn(4, 99)];
+  expect(otherWearers(items, 99, ROWS))
+    .toEqual(new Map([[1, "Kantra the Cyclone"], [2, "Elhain"]]));
+});
+
+// A placeholder Champs row is dropped by readChampRows but still owns gear. Naming it by id beats
+// reporting the piece as free, which is the one answer that is certainly wrong.
+test("otherWearers falls back to the champion id when the roster has no name for it", () => {
+  expect(otherWearers([worn(1, 77)], 0, ROWS)).toEqual(new Map([[1, "#77"]]));
+});
+
+test("otherWearers treats a missing equippedChampId as unequipped", () => {
+  expect(otherWearers([item({ id: 1 })], 0, ROWS)).toEqual(new Map());
+});
+
+// Busiest wearer first, then alphabetical, so a rerun on the same snapshot prints the same line.
+test("describeWearers counts the borrowed items and groups them by wearer", () => {
+  const items = [item({ id: 1 }), item({ id: 2 }), item({ id: 3 }), item({ id: 4 })];
+  const wearers = new Map([[1, "Elhain"], [2, "Kantra"], [3, "Kantra"], [4, "Athel"]]);
+  expect(describeWearers(items, wearers)).toBe("4 of 4 — Kantra x2, Athel, Elhain");
+});
+
+test("describeWearers says none when nothing in the build is spoken for", () => {
+  expect(describeWearers([item({ id: 1 })], new Map())).toBe("none");
+  expect(describeWearers([], new Map())).toBe("none");
+});
+
+// The map is vault-wide, so it holds items this build does not contain; only the build's own pieces
+// may reach the count.
+test("describeWearers counts only items the build actually contains", () => {
+  expect(describeWearers([item({ id: 1 })], new Map([[1, "Elhain"], [9, "Kantra"]])))
+    .toBe("1 of 1 — Elhain");
+});
+
+// Nine pieces off nine champions is a 200-character line. The COUNT is the fact that decides whether
+// the build is actionable and is never truncated; the tail of the name list is singletons already
+// printed against their own item a few lines above.
+test("describeWearers names the busiest four wearers and totals the rest", () => {
+  const items = [1, 2, 3, 4, 5, 6, 7].map((id) => item({ id }));
+  const wearers = new Map([[1, "Athel"], [2, "Bolgar"], [3, "Bolgar"], [4, "Cardiel"],
+    [5, "Doompriest"], [6, "Elhain"], [7, "Fahrakin"]]);
+  expect(describeWearers(items, wearers))
+    .toBe("7 of 7 — Bolgar x2, Athel, Cardiel, Doompriest, +2 more");
+});
+
+test("describeWearers adds no tail when every wearer is named", () => {
+  const items = [1, 2, 3, 4].map((id) => item({ id }));
+  const wearers = new Map([[1, "Athel"], [2, "Bolgar"], [3, "Cardiel"], [4, "Doompriest"]]);
+  expect(describeWearers(items, wearers)).toBe("4 of 4 — Athel, Bolgar, Cardiel, Doompriest");
 });
 
 // --- topBuilds / rankBuilds -------------------------------------------------
@@ -287,7 +374,8 @@ test("topBuilds' winner is solve's winner, and the rest descend from it without 
           expect(buildSpeed(base, constant, ranked[i].items, plain)).toBe(ranked[i].speed);
           // The printer's independent reconciliation must agree with the solver on every build it
           // is ever handed, which is what makes its MISMATCH marker meaningful when it does fire.
-          expect(formatBuild(ranked[i], base, constant, 0, new Map())).not.toContain("MISMATCH");
+          expect(formatBuild(ranked[i], base, constant, 0, new Map(), new Map()))
+            .not.toContain("MISMATCH");
           if (i > 0) expect(ranked[i].speed).toBeLessThanOrEqual(ranked[i - 1].speed);
         }
         const keys = ranked.map((b) => b.items.map((it) => it.id).sort((x, y) => x - y).join(","));

--- a/oracle/analytics/__tests__/speed-corpus.test.mjs
+++ b/oracle/analytics/__tests__/speed-corpus.test.mjs
@@ -7,7 +7,7 @@ import { test, expect } from "vitest";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { parseCorpus, loadCorpus, lookupBase } from "../speed-corpus.mjs";
+import { parseCorpus, loadCorpus, lookupBase, squashName } from "../speed-corpus.mjs";
 
 function tempDir() {
   const dir = mkdtempSync(join(tmpdir(), "speed-corpus-"));
@@ -108,6 +108,76 @@ test("lookupBase tolerates a non-string name", () => {
   const c = parseCorpus({ "Arbiter": 110 });
   expect(lookupBase(c, 42)).toBe(null);
   expect(lookupBase(c, null)).toBe(null);
+});
+
+// --- the punctuation fallback -----------------------------------------------
+
+test("squashName strips every non-alphanumeric character and lowercases the rest", () => {
+  expect(squashName("Krok’mar the Devourer")).toBe("krokmarthedevourer");
+  expect(squashName("Fyna, Blade of Aravia")).toBe("fynabladeofaravia");
+  expect(squashName("Belletar Mage-slayer")).toBe("belletarmageslayer");
+  expect(squashName("Big 'Un")).toBe("bigun");
+  expect(squashName(42)).toBe("42");
+});
+
+// The game spells champion names with apostrophes (both ASCII and typographic), commas, colons and
+// hyphens; a corpus that has been through a slug or an OCR pass often has not. It is not even
+// consistent about it — the same corpus can drop an apostrophe outright ("mashalled") and turn a
+// hyphen into a space ("belletar mage slayer") — so stripping EVERY non-alphanumeric from both sides
+// is the only form the two reliably agree on. Without this, 17 of the 20 champions the CLI reports
+// as "not in the corpus" are in it.
+test("lookupBase matches a corpus that dropped the punctuation from its names", () => {
+  const c = parseCorpus({
+    "mashalled": 103, "krokmar the devourer": 102, "xena warrior princess": 100,
+    "belletar mage slayer": 108, "big un": 104, "fyna blade of aravia": 113,
+  });
+  expect(lookupBase(c, "Ma'Shalled")).toBe(103);
+  expect(lookupBase(c, "Krok’mar the Devourer")).toBe(102);
+  expect(lookupBase(c, "Xena: Warrior Princess")).toBe(100);
+  expect(lookupBase(c, "Belletar Mage-slayer")).toBe(108);
+  expect(lookupBase(c, "Big 'Un")).toBe(104);
+  expect(lookupBase(c, "Fyna, Blade of Aravia")).toBe(113);
+});
+
+// A fallback, not a replacement: a corpus that DOES keep punctuation must keep answering exactly as
+// it did before, which is why the squash cannot simply be applied to both sides unconditionally.
+test("lookupBase prefers an exact match over the punctuation-stripped fallback", () => {
+  const c = parseCorpus({ "krok’mar the devourer": 102, "krokmar the devourer": 999 });
+  expect(lookupBase(c, "Krok’mar the Devourer")).toBe(102);
+});
+
+// The cost of a looser key is that two DIFFERENT champions could land on one. When they do, the
+// corpus cannot say which was meant, so the champion is reported absent and the user is sent to
+// --base — the same answer as before the fallback existed, never a guess. (The pair here is
+// illustrative; no two names in any corpus checked so far collide.)
+test("lookupBase refuses the fallback when two corpus names collide on different speeds", () => {
+  const c = parseCorpus({ "Skullcrusher": 90, "Skull Crusher": 101 });
+  expect(lookupBase(c, "Skull-Crusher")).toBe(null);
+  expect(lookupBase(c, "Skullcrusher")).toBe(90);
+});
+
+// Two spellings of ONE champion — the realistic collision, since a corpus merged from several files
+// can hold both — are not a disagreement, and refusing them would re-create the miss this fixes.
+test("lookupBase still answers when colliding corpus names agree on the speed", () => {
+  const c = parseCorpus({ "krokmar the devourer": 102, "krok mar the devourer": 102 });
+  expect(lookupBase(c, "Krok’mar the Devourer")).toBe(102);
+});
+
+// Absent stays absent: the looser key must not manufacture a match out of a name the corpus has
+// never heard of, and a speed of 0 reached through the fallback is still a speed, not a miss.
+test("the fallback neither invents a match nor turns a 0 into one", () => {
+  const c = parseCorpus({ "arbiter": 110, "zero": 0 });
+  expect(lookupBase(c, "Arbiter's Rival")).toBe(null);
+  expect(lookupBase(c, "Arbite")).toBe(null);
+  expect(lookupBase(c, "Ze-ro")).toBe(0);
+});
+
+// A name that squashes to nothing must not match a corpus key that also squashes to nothing —
+// otherwise every punctuation-only string collapses onto the same key and matches whatever is there.
+test("a name with no alphanumerics never matches through the fallback", () => {
+  const c = parseCorpus({ "--": 50, "Arbiter": 110 });
+  expect(lookupBase(c, "'")).toBe(null);
+  expect(lookupBase(c, "")).toBe(null);
 });
 
 // --- loadCorpus -------------------------------------------------------------

--- a/oracle/analytics/__tests__/speed-solve.prop.test.mjs
+++ b/oracle/analytics/__tests__/speed-solve.prop.test.mjs
@@ -3,8 +3,9 @@
 // claim is checkable directly — so check it.
 import { test, expect } from "vitest";
 import fc from "fast-check";
-import { buildIndex, solve, SLOTS } from "../speed-solve.mjs";
+import { buildIndex, enumeratePlans, solve, viableSets, SLOTS } from "../speed-solve.mjs";
 import { speedOfWith, buildSpeed } from "../speed-model.mjs";
+import { TIERED_SPEED_SETS } from "../speed-sets.mjs";
 
 const NUM_RUNS = Number(process.env.FC_NUM_RUNS) || 300;
 const plain = speedOfWith(0, new Map());
@@ -37,17 +38,57 @@ function bruteForce(items, base, constant) {
   return best;
 }
 
-// Sets chosen to span both mechanics: 4 and 38 are classic 2-piece stackers with different values,
-// 35 is tiered with the odd 2/4/8 thresholds, 0 is setless.
-const SETS = [0, 4, 38, 35];
+// Sets chosen to span every mechanic the solver has to reason about: 0 is setless; 4 and 38 are
+// classic 2-piece stackers with different values; 50 is the classic 4-piece one; 35 is tiered on the
+// odd 2/4/8 thresholds; 58 and 47 are tiered on the usual 3/5/8 with payouts in different orders;
+// 59 is tiered but stops after two rungs.
+const SETS = [0, 4, 38, 50, 35, 58, 47, 59];
 
-const instance = fc.array(
-  fc.record({
-    slot: fc.constantFrom(...SLOTS.slice(0, 4)),
-    set: fc.constantFrom(...SETS),
-    speed: fc.integer({ min: 0, max: 40 }),
-  }),
-  { minLength: 1, maxLength: 10 },
+// Four sets active at once is the `current.length === 4` cap in enumeratePlans, and reaching it needs
+// four sets whose FIRST threshold is 2 (4 x 2 = 8 <= 9 slots). Drawing from only these makes that
+// state ordinary rather than a coincidence — 15% of instances against 7% with setless in the mix,
+// measured. Setless pieces, and the free picks that complete a set by accident, are the wide draw's
+// job.
+const CHEAP_SETS = [4, 38, 53, 35];
+
+// Every tier SHAPE: 3/5/8, 2/4/8, 3/7, and 3/5/8 with the payouts front-loaded.
+const TIERED_SETS = [58, 47, 35, 59, 66];
+
+// One list of items PER SLOT, rather than a flat array whose slots are drawn at random. An instance
+// can then put a set in all nine slots — which is what the 8-piece tier and the four-set cap need,
+// and what a flat array of a dozen items reaches only by accident. At most two items per slot caps
+// the exhaustive search at 2^9.
+//
+// The populated slots are always a prefix of SLOTS. That costs nothing: buildIndex, assign and solve
+// key on the slot rather than reading it, and every generated item is a non-accessory, so which nine
+// slots they are is not a distinction any of them can make.
+//
+// `minSlots` is what makes the targeted draws below land. fc.array biases short, so an unconstrained
+// nine-slot generator averages five populated slots and reaches the states needing eight or nine
+// only by luck — 3% of instances rather than 14%, measured.
+const instanceWith = (setArb, minSlots = 1) => fc.array(
+  fc.array(fc.record({ set: setArb, speed: fc.integer({ min: 0, max: 40 }) }),
+    { minLength: 1, maxLength: 2 }),
+  { minLength: minSlots, maxLength: SLOTS.length },
+).map((perSlot) => perSlot.flatMap((specs, i) => specs.map((s) => ({ ...s, slot: SLOTS[i] }))));
+
+// Weighted three-to-one so one set really does reach eight of the nine slots often. An even draw
+// puts the 8-piece tier — the top of the ladder and the rung most easily missed — out of reach in
+// practice.
+const heavilyOneSet = (setId) => fc.oneof(
+  { arbitrary: fc.constant(setId), weight: 3 },
+  { arbitrary: fc.constant(0), weight: 1 },
+);
+
+// Three draws: a wide one that mixes every mechanic on any number of slots, one that piles a single
+// tiered set high enough to unlock all three of its rungs, and one that keeps four cheap sets in
+// play at once. Measured over 2,000 instances: 36% populate all nine slots, 11% supply some tiered
+// set from eight slots, 20% from five, 34% from three, and 15% enumerate a four-set plan. The test
+// at the bottom of this file holds those rates to it.
+const instance = fc.oneof(
+  instanceWith(fc.constantFrom(...SETS)),
+  fc.constantFrom(...TIERED_SETS).chain((setId) => instanceWith(heavilyOneSet(setId), 8)),
+  instanceWith(fc.constantFrom(...CHEAP_SETS), 8),
 );
 
 test("solve returns the same maximum as exhaustive search", () => {
@@ -76,4 +117,39 @@ test("solve is never worse than taking the fastest item in each slot", () => {
     }),
     { numRuns: NUM_RUNS },
   );
+});
+
+// The generator IS the test. When it narrows, nothing else here complains — which is how this file
+// came to draw from four slots and one tiered set while claiming to prove a nine-slot solver exact.
+// So the states the property exists to cover are asserted reachable rather than left to inspection.
+//
+// Unseeded and sampled wide on purpose: the rarest of these lands in about 11% of instances, so the
+// floor below sits nine standard deviations clear of it, while a fixed seed would make the check
+// hostage to fast-check changing how it generates between versions.
+const tiersOf = (setId) => TIERED_SPEED_SETS[setId]?.tiers.map(([threshold]) => threshold) ?? [];
+
+test("the generator reaches every state the property is supposed to cover", () => {
+  const seen = { nineSlots: 0, eighthRung: 0, fifthRung: 0, thirdRung: 0, fourSets: 0 };
+  for (const specs of fc.sample(instance, 2000)) {
+    const items = specs.map((s, i) => mkItem(i + 1, s.slot, s.set, s.speed));
+    const index = buildIndex(items, 0, plain);
+    if (index.size === SLOTS.length) seen.nineSlots++;
+    // How many distinct slots could supply each set — the same quantity viableSets works from, and
+    // what decides which tier rungs are reachable at all.
+    const supply = new Map();
+    for (const bySet of index.values()) {
+      for (const setId of bySet.keys()) supply.set(setId, (supply.get(setId) ?? 0) + 1);
+    }
+    const rung = (n) => [...supply].some(([setId, slots]) => slots >= n && tiersOf(setId).includes(n));
+    if (rung(8)) seen.eighthRung++;
+    if (rung(5)) seen.fifthRung++;
+    if (rung(3)) seen.thirdRung++;
+    if (enumeratePlans(index, viableSets(index)).some((plan) => plan.length === 4)) seen.fourSets++;
+  }
+  // 5%, not "at least once": a state the generator reaches twice in 2,000 draws is not covered by
+  // the 300 the property above actually runs. At 5% every one of these is hit a dozen times or more
+  // in a default run, and several hundred times in a fuzz shard.
+  for (const [state, hits] of Object.entries(seen)) {
+    expect(hits, `${state} is generated too rarely to count as covered`).toBeGreaterThan(100);
+  }
 });

--- a/oracle/analytics/champion-gear.mjs
+++ b/oracle/analytics/champion-gear.mjs
@@ -13,7 +13,7 @@
 import { readdirSync, realpathSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { ARTIFACT_SET_NAMES, ARTIFACT_SLOT_NAMES, FACTION_NAMES, lookupName } from "@rslh/core";
-import { isRealChamp, parseArgs, readChampRows, selectChamps } from "./champs.mjs";
+import { isRealChamp, parseArgs, readChampRows, selectChamps, suggestNames } from "./champs.mjs";
 import { readArtifacts } from "./decode.mjs";
 import { keepPremium, triage } from "./triage.mjs";
 import { quality, qualityAtRole } from "./score.mjs";
@@ -271,8 +271,8 @@ function main() {
 
   if (selector !== null && !matched.length) {
     console.error(`no champion matches "${selector}".`);
-    const near = rows.filter((r) => r.Name.toLowerCase().startsWith(String(selector).slice(0, 3).toLowerCase()));
-    if (near.length) console.error(`did you mean: ${[...new Set(near.map((r) => r.Name))].slice(0, 8).join(", ")}?`);
+    const near = suggestNames(rows, selector);
+    if (near.length) console.error(`did you mean: ${near.join(", ")}?`);
     process.exit(1);
   }
   if (!targets.length) {

--- a/oracle/analytics/champs.mjs
+++ b/oracle/analytics/champs.mjs
@@ -29,6 +29,16 @@ export function selectChamps(rows, selector) {
   return rows.filter((r) => r.Name.toLowerCase().includes(nf));
 }
 
+// What to offer after a selector matched nothing. A shared prefix, not an edit distance: the
+// realistic miss is a half-remembered or half-typed name, and the opening characters are what the
+// user is most likely to have right. Deduplicated because the roster holds one row per COPY, and
+// capped because a three-character prefix can cover a lot of a 500-champion roster.
+export function suggestNames(rows, selector, limit = 8) {
+  const prefix = String(selector).slice(0, 3).toLowerCase();
+  const near = rows.filter((r) => r.Name.toLowerCase().startsWith(prefix));
+  return [...new Set(near.map((r) => r.Name))].slice(0, limit);
+}
+
 // --- I/O --------------------------------------------------------------------
 
 // readOnly makes SELECT-only structural rather than conventional, and — the reason it's here — it

--- a/oracle/analytics/speed-corpus.mjs
+++ b/oracle/analytics/speed-corpus.mjs
@@ -75,4 +75,34 @@ export function loadCorpus(path) {
   return corpus;
 }
 
-export const lookupBase = (corpus, name) => corpus.get(String(name).toLowerCase()) ?? null;
+// The fallback key for a name the corpus does not hold verbatim. The game spells champions with
+// apostrophes (ASCII and typographic), commas, colons and hyphens; a corpus that has been through a
+// slug or an OCR pass often has not, and is not consistent about how — the same one can drop an
+// apostrophe outright ("mashalled") and turn a hyphen into a space ("belletar mage slayer"). No
+// single rewrite reconciles those, so this strips ALL of it from both sides.
+export const squashName = (name) => String(name).toLowerCase().replace(/[^a-z0-9]+/g, "");
+
+// The exact lowercased key first, so a corpus that keeps its punctuation answers byte-for-byte and
+// never reaches the scan below — this widens what can be FOUND without changing any answer that was
+// already found. Only a miss pays for the scan, and a miss is rare by construction.
+//
+// A looser key can put two different champions on one key, so a collision is REFUSED rather than
+// resolved: the corpus cannot say which was meant, and reporting absent sends the user to --base,
+// which is where they already were. Colliding entries that agree on the speed are not a collision in
+// the only respect that matters, and answering them is the point of the fallback — a corpus merged
+// from several files can easily hold two spellings of one champion.
+export function lookupBase(corpus, name) {
+  const exact = corpus.get(String(name).toLowerCase());
+  if (exact !== undefined) return exact;
+  const key = squashName(name);
+  // Every punctuation-only name squashes to "", and so does any such corpus key. Matching them to
+  // each other would be a coincidence of shape, not a name lookup.
+  if (key === "") return null;
+  let found;
+  for (const [candidate, spd] of corpus) {
+    if (squashName(candidate) !== key) continue;
+    if (found !== undefined && found !== spd) return null;
+    found = spd;
+  }
+  return found ?? null;
+}

--- a/oracle/analytics/speed.mjs
+++ b/oracle/analytics/speed.mjs
@@ -15,7 +15,7 @@ import { readdirSync, realpathSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { ARTIFACT_SET_NAMES, ARTIFACT_SLOT_NAMES, lookupName } from "@rslh/core";
 import { readArtifacts } from "./decode.mjs";
-import { readChampRows, selectChamps } from "./champs.mjs";
+import { readChampRows, selectChamps, suggestNames } from "./champs.mjs";
 import { SPD, glyphCeilings, clampFloor, speedOfWith, measureConstant, itemSpeed, buildSpeed,
   setCounts } from "./speed-model.mjs";
 import { SLOTS, buildIndex, solve, enumeratePlans, assign, viableSets } from "./speed-solve.mjs";
@@ -298,11 +298,8 @@ function main() {
   const matched = selectChamps(rows, args.selector);
   if (!matched.length) {
     console.error(`no champion matches "${args.selector}".`);
-    const near = rows.filter((r) =>
-      r.Name.toLowerCase().startsWith(String(args.selector).slice(0, 3).toLowerCase()));
-    if (near.length) {
-      console.error(`did you mean: ${[...new Set(near.map((r) => r.Name))].slice(0, 8).join(", ")}?`);
-    }
+    const near = suggestNames(rows, args.selector);
+    if (near.length) console.error(`did you mean: ${near.join(", ")}?`);
     process.exit(1);
   }
 

--- a/oracle/analytics/speed.mjs
+++ b/oracle/analytics/speed.mjs
@@ -71,6 +71,52 @@ export function describeSets(counts, base) {
   return parts.length ? parts.join(" · ") : "no speed sets";
 }
 
+// itemId -> the name of the champion wearing it right now, for the pieces that would have to come
+// OFF someone. A free piece costs nothing to fit, and neither does one already on `champId`, so
+// neither is listed — including them would bury the ones that do cost something.
+//
+// Built once per champion over the whole vault rather than per build, because --top prints several
+// builds drawn from the same pool.
+export function otherWearers(items, champId, rows) {
+  const names = new Map(rows.map((r) => [Number(r.ID), r.Name]));
+  const out = new Map();
+  for (const it of items) {
+    const owner = it.equippedChampId;
+    if (!owner || owner === champId) continue;
+    // A placeholder Champs row is dropped by readChampRows but still owns gear. Naming the owner by
+    // id beats reporting the piece as free, which is the one answer that is certainly wrong.
+    out.set(it.id, names.get(owner) ?? `#${owner}`);
+  }
+  return out;
+}
+
+// "8 of 9 — Kantra the Cyclone x3, Elhain x2, Kael", or "none".
+//
+// The solver's pool is the WHOLE vault, worn gear included — a deliberate choice, since gear can be
+// moved. The consequence is that solving several champions independently proposes the same physical
+// pieces to each, so the builds are mutually exclusive. Printed for every build, `none` included:
+// silence would be indistinguishable from a report that does not check.
+//
+// Busiest wearer first, then alphabetical, so a rerun on one snapshot prints the same line. Names
+// past the fourth become "+N more" — nine pieces off nine champions is a 200-character line, and
+// the tail of it is singletons already named against their own item a few lines above.
+const NAMED_WEARERS = 4;
+
+export function describeWearers(items, wearers) {
+  const byChamp = new Map();
+  for (const it of items) {
+    const who = wearers.get(it.id);
+    if (who === undefined) continue;
+    byChamp.set(who, (byChamp.get(who) ?? 0) + 1);
+  }
+  if (byChamp.size === 0) return "none";
+  const taken = [...byChamp.values()].reduce((sum, n) => sum + n, 0);
+  const ranked = [...byChamp].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
+  const named = ranked.slice(0, NAMED_WEARERS).map(([who, n]) => (n > 1 ? `${who} x${n}` : who));
+  const rest = ranked.length - named.length;
+  return `${taken} of ${items.length} — ${[...named, ...(rest ? [`+${rest} more`] : [])].join(", ")}`;
+}
+
 // The last line is a RECONCILIATION, not a restatement. Every term is computed independently and the
 // total is added up from them, so the line can disagree with what the solver returned — and says so
 // when it does. Deriving `sets` as `speed - base - items - constant` instead would balance for every
@@ -80,7 +126,7 @@ export function describeSets(counts, base) {
 // table other than the one the build was solved under. What it cannot catch is a stale set
 // percentage — `solve` and `describeSets` both go through `setEffect`, so they would agree on the
 // same wrong number. That gap is `verify`'s job, not this line's.
-export function formatBuild(result, base, constant, glyphFloor, ceilings) {
+export function formatBuild(result, base, constant, glyphFloor, ceilings, wearers) {
   const lines = [];
   const flat = result.items.reduce((sum, it) => sum + itemSpeed(it, clampFloor(it, glyphFloor, ceilings)), 0);
   const bonus = setEffect(base, result.counts);
@@ -88,9 +134,12 @@ export function formatBuild(result, base, constant, glyphFloor, ceilings) {
   lines.push(`  ${result.speed} SPD   ${describeSets(result.counts, base)}`);
   for (const it of [...result.items].sort((a, b) => a.slot - b.slot)) {
     const s = itemSpeed(it, clampFloor(it, glyphFloor, ceilings));
+    const on = wearers.get(it.id);
     lines.push(`    ${slotName(it.slot).padEnd(7)} ${setLabel(it.set).padEnd(14)}`
-      + ` +${String(it.level).padStart(2)}   spd ${String(s).padStart(3)}   #${it.id}`);
+      + ` +${String(it.level).padStart(2)}   spd ${String(s).padStart(3)}   #${it.id}`
+      + (on ? `   on ${on}` : ""));
   }
+  lines.push(`    on other champions: ${describeWearers(result.items, wearers)}`);
   lines.push(`    base ${base} + sets ${bonus} + items ${flat} + constant ${constant} = ${total}`
     + (total === result.speed ? "" : `   MISMATCH: the solver said ${result.speed}`));
   return lines.join("\n");
@@ -221,10 +270,10 @@ function runVerify(items, rows, corpus) {
 
 // BEST is printed by the caller, which knows what its headline delta is measured against; the
 // runners-up are all measured against BEST.
-function printRanked(ranked, base, constant, glyphFloor, ceilings) {
+function printRanked(ranked, base, constant, glyphFloor, ceilings, wearers) {
   ranked.forEach((build, i) => {
     if (i > 0) console.log(`\n  #${i + 1}  (${build.speed - ranked[0].speed} off BEST)`);
-    console.log(formatBuild(build, base, constant, glyphFloor, ceilings));
+    console.log(formatBuild(build, base, constant, glyphFloor, ceilings, wearers));
   });
 }
 
@@ -279,8 +328,10 @@ function main() {
     const index = buildIndex(items, champ.Fraction, plainSpeed);
     const ranked = rankBuilds(index, base, constant, plainSpeed, args.top);
     if (!ranked.length) { console.log("  no eligible items for any slot."); continue; }
+    // Same pool for every build printed for this champion, plain and glyph-lifted alike.
+    const wearers = otherWearers(items, champ.ID, rows);
     console.log(`  BEST  (+${ranked[0].speed - champ.SPD} over current)`);
-    printRanked(ranked, base, constant, 0, ceilings);
+    printRanked(ranked, base, constant, 0, ceilings, wearers);
 
     if (args.glyph > 0) {
       const glyphSpeed = speedOfWith(args.glyph, ceilings);
@@ -293,7 +344,7 @@ function main() {
         && clampFloor(it, args.glyph, ceilings) < args.glyph).length;
       console.log(`\n  at glyph >= ${args.glyph}  (+${lifted[0].speed - ranked[0].speed} over BEST)`
         + `${clamped ? `   [${clamped} vault items clamped to their rarity ceiling]` : ""}`);
-      printRanked(lifted, base, constant, args.glyph, ceilings);
+      printRanked(lifted, base, constant, args.glyph, ceilings, wearers);
     }
   }
 }


### PR DESCRIPTION
Closes the four Important findings from the champion speed solver's final whole-branch review. The review's verdict on the branch itself was ship-it with 0 Critical; these are the items it said to fix before anyone leans on the tool.

## What changed

**Find the champions the corpus already holds.** The lookup was rejecting 17 of the 20 champions it reported as "not in the corpus". Real champion names carry apostrophes, commas, colons and hyphens that a slug or OCR pass flattens, and matching on the lowercased name alone hid champions the corpus already had. Coverage goes from 456 to **473 of 476** geared names; the remaining 3 are genuine absences and still fail loudly rather than guessing.

The normalisation refuses a collision rather than resolving it — verified against the corpus that no two distinct names now collide on one key with different speeds, on both the 2026-08-12 and 2026-08-16 snapshots. A collision degrades to the pre-fix outcome, never to another champion's base speed.

**Say which champion is wearing each proposed item.** The solver draws from the whole vault by design, so solving champions independently proposes the same physical pieces to each and the builds are mutually exclusive. Nothing on screen said so — 8 of 9 items in a typical build are on other champions. Report layer only; the solver, the pool and the objective are unchanged.

**Make the exactness property cover the solver it proves.** The committed generator used slots 1–4 and a narrow set list, so it never reached the 3/5/8 tiered thresholds, the 8-piece tier, or the four-active-set cap — the branch's central claim was regression-protected only in a review file. The generator now reaches all of them.

**Write the "did you mean" suggestion once.** `champs.mjs` claimed the champion-selection UX was written once while the suggestion logic was duplicated in `speed.mjs`.

## Verification

- 654 tests across 40 files, all green (630 before).
- Independently re-reviewed: all four findings addressed, no new breakage, nothing previously covered weakened.
- The solver's returned maximum is unchanged by any of this.

## Not in scope

The review's 15 Minor findings are recorded for separate triage, along with the two larger items it flagged: ascension stats being invisible to `triage`/`score`/`quality`, and the open design question of which build to return when several tie on maximum speed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
