### PR TITLE
docs(battlelogs): correct how a Live Arena battle ends

### DIFF
--- a/docs/plans/2026-08-12-battle-log-capture-design.md
+++ b/docs/plans/2026-08-12-battle-log-capture-design.md
@@ -318,13 +318,58 @@ archive, not at capture time (see *Rejected alternatives*).
 
 Two cautions carried from these captures:
 
-- **Survivor counts are not outcomes.** Live Arena battles ended `4/3` and `4/4` (player/enemy survivors)
-  — wins on points with the enemy team still standing. A naive "enemy team wiped" rule would score
-  both as losses. This is the concrete evidence behind the *Index row* section's refusal to emit a
-  `win` field.
+- **Survivor counts are not outcomes.** Live Arena battles ended `4/3` and `4/4` (player/enemy
+  survivors) with the enemy team still standing. A naive "enemy team wiped" rule would score both as
+  losses. This is the concrete evidence behind the *Index row* section's refusal to emit a `win` field.
+
+  ~~— wins on points with the enemy team still standing.~~ **Wrong as written**, corrected
+  2026-08-19, and kept visible because it was quoted as authority and misled a later analysis into
+  looking for a score that does not exist. **Live Arena has no points.** Per the account owner there
+  are three end-conditions and only three:
+
+  | end condition | outcome |
+  |---|---|
+  | one team is wiped | the surviving team wins |
+  | one player leaves | the other player wins |
+  | 15-minute timeout | **both** players lose |
+
+  So a `4/3` or `4/4` win is an **opponent-left** win. The conclusion above is untouched — survivor
+  counts still are not outcomes — but the mechanism matters: "points" implies a score that might be
+  recoverable from the log, and there is no such quantity to recover.
 - **One session is not the id space.** Three of the five tuples above appeared only after a second
   night of capture, and none of 2026-08-12's two reappeared on 2026-08-13. Treat this table as
   "what has been seen", never "what exists".
+
+### How a battle ended is readable; who won is not
+
+Established 2026-08-19 over 10 Live Arena battles captured in one session, with outcomes supplied by
+the account owner (8 wins, 2 losses; screenshots for the wins).
+
+The **event kinds in the last push** separate the two observed end-conditions:
+
+| last push carries | ended by | battles |
+|---|---|---|
+| `dmg`, `HeroDeadResult`, `counter`, `skill` … | a team wiped | 4 |
+| `UnappliedEffectResult`, `StatsChangeResult`, `RoundFinishedResult` only | a player left | 6 |
+
+The six quiet ones are not a guess. The owner won five of them with the enemy at 3, 2, 1, 2 and 1
+deaths of 4 and the player side at 0 — so no team wiped, and a timeout loses for both, which a win
+excludes. Opponent-left is the only remaining branch. The sixth is the owner leaving a battle they
+were losing.
+
+The **15-minute timeout has never been captured.** The longest battle on record is 26 turns.
+
+What this does not give is the winner:
+
+- A wipe does not say *whose* team died. That is the per-side `dead` count, already in the row.
+- A quiet push does not say *which player* left, and nothing structural distinguishes the five
+  opponent-left battles from the one owner-left battle. Damage ratio does separate them empirically
+  — 3.53–∞ when the opponent left, 0.07 when the owner did — but that is players quitting when they
+  are losing, a behavioural regularity rather than a logged fact, and it inherits every bias of who
+  happens to be playing.
+
+Neither belongs in a `win` field. The end-condition is a property of the log; the outcome is not in
+it, and for a left battle it is decided after the last byte is written.
 
 ## Architecture
 

--- a/oracle/battlelogs/README.md
+++ b/oracle/battlelogs/README.md
@@ -39,14 +39,24 @@ That `ownerId` is a **three-way** test:
 | `ownerId` | opponent | seen |
 |---|---|---|
 | `-1` | AI | every non-arena tuple so far |
-| negative, but not `-1` | **Live Arena bot** | `-94341`, 2026-08-17 |
+| negative, but not `-1` | **Live Arena bot** | `-94341` 2026-08-17; `-94211`, `-94414` 2026-08-19 |
 | positive | real player | Live Arena; **not** unique per battle, one has already recurred |
 
 Live Arena hands you a bot after three losses in a row, or when you let the pick phase time out
 (about a minute). Its team is generated rather than a real player's build, so it has to stay out of
-any opponent corpus — one bot in the 38 Live Arena battles captured through 2026-08-17, and nothing
-else in the index row tells it apart: same tuple, same 4v4, ordinary champions. The sign of
-`ownerId` is the only marker.
+any opponent corpus — and nothing else in the index row tells it apart: same tuple, same 4v4,
+ordinary champions. The sign of `ownerId` is the only marker.
+
+**All three bots on record are pick-phase timeouts** (2026-08-19's two reported at the time, 08-17's
+by the owner's later recollection). The three-losses-in-a-row branch has **never been observed** —
+it is repeated here from outside the archive, so do not read it as captured.
+
+Bot rate is a property of how you play, not of the mode: 1 bot in the 38 battles through 2026-08-17,
+then 2 in a single 10-battle session on 08-19 that included several timed-out picks. An exclusion
+pass sized from the first figure will under-remove on a session like the second.
+
+Bots are not pushovers. `-94211` took 26 turns and killed 3 of 4 champions — the longest and costliest
+battle of that session.
 
 `DECODE FAILED (attempt n/3)` means only that: the bytes are archived either way, and the
 file is retried on the next two passes in case it was caught mid-write. After the third the decode
@@ -68,6 +78,33 @@ const lines = readBattle("archive/um.../20260812_232412_live.jsonl.z");   // one
 ```
 
 Format reference — envelope, teams, events: `docs/plans/2026-08-12-battle-log-capture-design.md`.
+
+### There is no winner in the log
+
+`finished: true` is on the **last line of every file** and no earlier one — it marks the end of the
+log, not the end of the battle. `eventsTruncated: false` says that one push's event array was not cut
+mid-write, nothing more. The last event is `RoundFinishedResult` in every battle. None of the three
+tells you a battle ran to completion, and reading them that way is a mistake that has been made here.
+
+What *is* readable is how the battle ended, from the last push's event kinds:
+
+| last push carries | ended by |
+|---|---|
+| `dmg`, `HeroDeadResult`, `counter`, `skill` … | a team wiped |
+| `UnappliedEffectResult`, `StatsChangeResult`, `RoundFinishedResult` only | a player left |
+
+Live Arena ends three ways — a team wipes (survivor wins), a player leaves (the other wins), or it
+times out at 15 minutes (**both** lose). There are no points. The timeout has never been captured.
+
+The log still does not say who won. A quiet last push does not say *which* side left, and when it
+was the opponent the result is decided after the last byte is written. Survivor counts are facts, not
+a verdict — see `summarize()` and the design doc's *How a battle ended is readable; who won is not*.
+
+So outcomes have to be recorded by hand, while they are still known. `archive/outcomes.jsonl` holds
+them keyed by battle filename, each row carrying how that field is known — owner-reported, screenshot,
+or derived from the log by the wipe rule. Gitignored like the rest of `archive/`, and unlike
+`index.jsonl` it is **not derived**: nothing can regenerate it, so it is the one file here worth
+backing up.
 
 ## Rebuild the index
 


### PR DESCRIPTION
Docs only — no code, no behaviour change.

The design doc explained two `4/3` and `4/4` Live Arena results as "wins on points with the enemy team still standing". **There are no points in Live Arena.** It ends exactly three ways: a team wipes and the survivor wins, a player leaves and the other wins, or it times out at 15 minutes and both lose. Those two were opponent-left wins.

The wrong sentence is **struck rather than deleted**, matching how the same section already handles its "10 different opponents" error. It had been quoted as authority and sent a later analysis hunting for a score that does not exist, which is exactly why it should stay visible.

The doc's conclusion is unchanged: survivor counts are still not outcomes, and there is still no `win` field.

Also folded in, from a 10-battle session on 2026-08-19 (8W–2L, outcomes hand-supplied, screenshots for the wins):

- **The last push's event kinds identify the end condition.** `dmg` / `HeroDeadResult` means a team wiped (4 battles); bookkeeping events alone mean a player left (6). The 15-minute timeout has never been captured.
- **`finished: true`, `eventsTruncated: false` and a trailing `RoundFinishedResult` appear on every file**, abandoned ones included — so none of them means a battle ran to completion. Written down because that misreading was actually made.
- **The end condition still does not give the winner.** A quiet last push does not say which side left, and when it was the opponent the result is decided after the last byte is written.
- **Two more bot ids** (`-94211`, `-94414`). All three on record are pick-phase timeouts; the three-losses-in-a-row branch has never been observed and is now marked as repeated from outside the archive rather than captured.
- **Bot rate tracks how you play, not the mode**: 1 in 38 battles, then 2 in a single 10-battle session with several timed-out picks. An exclusion pass sized from the first figure under-removes on a session like the second.

Outcomes cannot be recovered from the logs, so they are hand-recorded in `archive/outcomes.jsonl`, each row carrying how the field is known. Gitignored with the rest of `archive/`, and unlike `index.jsonl` it is **not derived** — nothing can regenerate it.

## Test plan

No code touched, so `npm test` is unaffected. Both files render as intended on GitHub (the struck sentence uses the existing `~~…~~` convention already in that section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0129E1Gk5aa3NCrfJ8Jwf88i
